### PR TITLE
pipeline: add local weighted semaphores

### DIFF
--- a/enduro.toml
+++ b/enduro.toml
@@ -45,6 +45,7 @@ processingDir = ""
 processingConfig = "automated"
 # transferLocationID = "88f6b517-c0cc-411b-8abf-79544ce96f54"
 storageServiceURL = "http://test:test@127.0.0.1:62081"
+capacity = 5
 
 [[hooks."hari"]]
 baseURL = "" # E.g.: "https://192.168.1.50:8080/api"

--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 	gocloud.dev v0.17.0
 	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f // indirect
 	golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 // indirect
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20191210023423-ac6580df4449 // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	golang.org/x/tools v0.0.0-20191210221141-98df12377212 // indirect

--- a/go.sum
+++ b/go.sum
@@ -647,6 +647,7 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/hack/test-dpj/Makefile
+++ b/hack/test-dpj/Makefile
@@ -34,6 +34,12 @@ err: FIXITY_ERR = yes
 err: push-tar
 
 TIMES ?= 10
+many-ok:
+	@for run in {1..$(TIMES)}; do \
+        make push-tar; \
+    done;
+
+TIMES ?= 10
 many:
 	@for run in {1..$(TIMES)}; do \
         fail=$$(shuf -e yes no -n 1); \

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -1,0 +1,40 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestPipelineSemaphore(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	p, err := NewPipeline(Config{Capacity: 3})
+	assert.ErrorContains(t, err, "error during pipeline identification")
+
+	tryAcquire := func(n int64) bool {
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+		defer cancel()
+		return p.Acquire(ctx) == nil
+	}
+
+	tries := []bool{}
+
+	// These three should succeed right away.
+	tries = append(tries, tryAcquire(1))
+	tries = append(tries, tryAcquire(1))
+	tries = append(tries, tryAcquire(1))
+
+	// And the one too because we've released once.
+	p.Release()
+	tries = append(tries, tryAcquire(1))
+
+	// But this will fail because all the slots are taken.
+	tries = append(tries, tryAcquire(1))
+
+	assert.DeepEqual(t, tries, []bool{true, true, true, true, false})
+}

--- a/internal/workflow/activities/acquire_pipeline.go
+++ b/internal/workflow/activities/acquire_pipeline.go
@@ -1,0 +1,26 @@
+package activities
+
+import (
+	"context"
+
+	"github.com/artefactual-labs/enduro/internal/workflow/manager"
+)
+
+// AcquirePipelineActivity acquires a lock in the weighted semaphore associated
+// to a particular pipeline.
+type AcquirePipelineActivity struct {
+	manager *manager.Manager
+}
+
+func NewAcquirePipelineActivity(m *manager.Manager) *AcquirePipelineActivity {
+	return &AcquirePipelineActivity{manager: m}
+}
+
+func (a *AcquirePipelineActivity) Execute(ctx context.Context, name string) error {
+	p, err := a.manager.Pipelines.ByName(name)
+	if err != nil {
+		return err
+	}
+
+	return p.Acquire(ctx)
+}

--- a/internal/workflow/activities/activities.go
+++ b/internal/workflow/activities/activities.go
@@ -1,12 +1,13 @@
 package activities
 
 const (
-	DownloadActivityName       = "download-activity"
-	BundleActivityName         = "bundle-activity"
-	TransferActivityName       = "transfer-activity"
-	PollTransferActivityName   = "poll-transfer-activity"
-	PollIngestActivityName     = "poll-ingest-activity"
-	CleanUpActivityName        = "clean-up-activity"
-	HidePackageActivityName    = "hide-package-activity"
-	DeleteOriginalActivityName = "delete-original-activity"
+	AcquirePipelineActivityName = "acquire-pipeline-activity"
+	DownloadActivityName        = "download-activity"
+	BundleActivityName          = "bundle-activity"
+	TransferActivityName        = "transfer-activity"
+	PollTransferActivityName    = "poll-transfer-activity"
+	PollIngestActivityName      = "poll-ingest-activity"
+	CleanUpActivityName         = "clean-up-activity"
+	HidePackageActivityName     = "hide-package-activity"
+	DeleteOriginalActivityName  = "delete-original-activity"
 )

--- a/internal/workflow/local_activities.go
+++ b/internal/workflow/local_activities.go
@@ -4,9 +4,22 @@ import (
 	"context"
 
 	"github.com/artefactual-labs/enduro/internal/collection"
+	"github.com/artefactual-labs/enduro/internal/pipeline"
 	"github.com/artefactual-labs/enduro/internal/workflow/manager"
+
 	"go.uber.org/cadence/activity"
 )
+
+func releasePipelineLocalActivity(ctx context.Context, registry *pipeline.Registry, name string) error {
+	p, err := registry.ByName(name)
+	if err != nil {
+		return err
+	}
+
+	p.Release()
+
+	return nil
+}
 
 func createPackageLocalActivity(ctx context.Context, colsvc collection.Service, tinfo *TransferInfo) (*TransferInfo, error) {
 	info := activity.GetInfo(ctx)

--- a/internal/workflow/policies.go
+++ b/internal/workflow/policies.go
@@ -30,6 +30,15 @@ func withActivityOptsForLongLivedRequest(ctx workflow.Context) workflow.Context 
 	})
 }
 
+// withActivityOptsForUnlimitedTime returns a workflow context with activity
+// options suited for activities that can take a long time to run.
+func withActivityOptsForUnlimitedTime(ctx workflow.Context) workflow.Context {
+	return workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		ScheduleToStartTimeout: time.Hour * 1,
+		StartToCloseTimeout:    forever,
+	})
+}
+
 // withActivityOptsForHeartbeatedRequest returns a workflow context with
 // activity options suited for long-lived activities implementing heartbeats.
 //

--- a/main.go
+++ b/main.go
@@ -208,6 +208,7 @@ func main() {
 
 		cadence.RegisterWorkflow(workflow.NewProcessingWorkflow(m).Execute, collection.ProcessingWorkflowName)
 
+		cadence.RegisterActivity(activities.NewAcquirePipelineActivity(m).Execute, activities.AcquirePipelineActivityName)
 		cadence.RegisterActivity(activities.NewDownloadActivity(m).Execute, activities.DownloadActivityName)
 		cadence.RegisterActivity(activities.NewBundleActivity().Execute, activities.BundleActivityName)
 		cadence.RegisterActivity(activities.NewTransferActivity(m).Execute, activities.TransferActivityName)


### PR DESCRIPTION
This is the simplest version I could think of to address resource constraint in response to @jorikvankemenade's feature request. It uses a local weighted semaphore with capacity determined via configuration. It does not require changes in Archivematica (which won't have native rate-limiting until v1.12 at the very least), but it can't tell if a pipeline was already busy from interacting with other users (other than Enduro).

It is definitely improvable. Major limitations:
* The semaphore is local to the main process. We'd need to move to a distributed semaphore once we start deploying Enduro in a distributed fashion.
* All collections go into "in progress" even when they're queued or blocked waiting for the semaphore to be acquired. We could add an intermediate status, e.g. "queued"?
* If you terminate a workflow abruptly then the application won't have a chance to release the semaphore. Just don't terminate workflows from Cadence's CLI unless it's necessary. Termination is better, since it gives the workflow an opportunity to exit gracefully, e.g. to release the semaphore. Also, locks don't expire. If you run into a deadlock, you'll have to restart the process.