### PR TITLE
pipeline: polish semaphore usage

### DIFF
--- a/internal/workflow/activities/acquire_pipeline.go
+++ b/internal/workflow/activities/acquire_pipeline.go
@@ -2,6 +2,7 @@ package activities
 
 import (
 	"context"
+	"time"
 
 	"github.com/artefactual-labs/enduro/internal/workflow/manager"
 )
@@ -21,6 +22,9 @@ func (a *AcquirePipelineActivity) Execute(ctx context.Context, name string) erro
 	if err != nil {
 		return err
 	}
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
 
 	return p.Acquire(ctx)
 }

--- a/internal/workflow/policies.go
+++ b/internal/workflow/policies.go
@@ -30,15 +30,6 @@ func withActivityOptsForLongLivedRequest(ctx workflow.Context) workflow.Context 
 	})
 }
 
-// withActivityOptsForUnlimitedTime returns a workflow context with activity
-// options suited for activities that can take a long time to run.
-func withActivityOptsForUnlimitedTime(ctx workflow.Context) workflow.Context {
-	return workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-		ScheduleToStartTimeout: time.Hour * 1,
-		StartToCloseTimeout:    forever,
-	})
-}
-
 // withActivityOptsForHeartbeatedRequest returns a workflow context with
 // activity options suited for long-lived activities implementing heartbeats.
 //


### PR DESCRIPTION
* Retry acquire so the activity doesn't block forever.
* Recover when release operation panics.