### PR TITLE
timeouts: improve timeout handling for large files 

### DIFF
--- a/internal/workflow/policies.go
+++ b/internal/workflow/policies.go
@@ -18,14 +18,17 @@ const forever = time.Hour * 24 * 365 * 10
 func withActivityOptsForLongLivedRequest(ctx workflow.Context) workflow.Context {
 	return workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		ScheduleToStartTimeout: forever,
-		StartToCloseTimeout:    time.Minute * 10,
+		StartToCloseTimeout:    time.Hour * 2,
 		RetryPolicy: &cadence.RetryPolicy{
-			InitialInterval:          time.Second,
-			BackoffCoefficient:       2,
-			MaximumInterval:          time.Minute * 10,
-			ExpirationInterval:       time.Minute * 10,
-			MaximumAttempts:          5,
-			NonRetriableErrorReasons: []string{wferrors.NRE},
+			InitialInterval:    time.Second,
+			BackoffCoefficient: 2,
+			MaximumInterval:    time.Minute * 10,
+			ExpirationInterval: time.Minute * 10,
+			MaximumAttempts:    5,
+			NonRetriableErrorReasons: []string{
+				wferrors.NRE,
+				"cadenceInternal:Timeout START_TO_CLOSE",
+			},
 		},
 	})
 }


### PR DESCRIPTION
When transferring multiple large files we get ingest timeouts as described in #51 and download timeouts as discussed in #50. This PR addresses both issues:

1. `IngestStatus` retries on on `net.Error` timeouts. 
1.  `withActivityOptsForLongLivedRequest` defines a longer timeout, allowing large downloads to finish.
1. `withActivityOptsForLongLivedRequest` does not retry on the activity timing out. Thus making sure that a *complete* download will only time out once. 

I think that we could maybe improve a little bit on the error handling in `IngestStatus`, see my comments in commit d1dc144. However, this might be more appropriately scoped with some possible future error handling work. 

Closes #50, #51  