### PR TITLE
Make fs watchers usable for big transfers

### DIFF
--- a/enduro.toml
+++ b/enduro.toml
@@ -30,9 +30,10 @@ stripTopLevelDir = true
 [[watcher.filesystem]]
 name = "dev-fs"
 path = "./hack/watched-dir"
-inotify = true
+inotify = false
 pipeline = "am"
 retentionPeriod = "11s"
+ignore = "^*\\.mft$"
 stripTopLevelDir = true
 
 [[pipeline]]

--- a/internal/filenotify/filenotify.go
+++ b/internal/filenotify/filenotify.go
@@ -43,7 +43,7 @@ func NewPollingWatcher() (FileWatcher, error) {
 		events: make(chan fsnotify.Event),
 		errors: make(chan error),
 	}
-	poller.wr.FilterOps(watcher.Create)
+	poller.wr.FilterOps(watcher.Create, watcher.Rename, watcher.Move)
 	go poller.loop()
 
 	done := make(chan error)

--- a/internal/filenotify/poller.go
+++ b/internal/filenotify/poller.go
@@ -28,11 +28,21 @@ func (w *filePoller) loop() {
 	for {
 		select {
 		case event := <-w.wr.Event:
-			if event.Op != watcher.Create {
+			var op fsnotify.Op
+
+			switch event.Op {
+			case watcher.Create:
+				op = fsnotify.Create
+			case watcher.Rename:
+				fallthrough
+			case watcher.Move:
+				op = fsnotify.Rename
+			default:
 				continue
 			}
+
 			w.events <- fsnotify.Event{
-				Op:   fsnotify.Create,
+				Op:   op,
 				Name: event.Path,
 			}
 		case err := <-w.wr.Error:

--- a/internal/watcher/config.go
+++ b/internal/watcher/config.go
@@ -12,6 +12,7 @@ type FilesystemConfig struct {
 	Name    string
 	Path    string
 	Inotify bool
+	Ignore  string
 
 	Pipeline         string
 	RetentionPeriod  *time.Duration

--- a/internal/watcher/filesystem.go
+++ b/internal/watcher/filesystem.go
@@ -76,7 +76,10 @@ func (w *filesystemWatcher) loop() {
 	for {
 		select {
 		case event, ok := <-w.fsw.Events():
-			if !ok || event.Op != fsnotify.Create {
+			if !ok {
+				continue
+			}
+			if event.Op != fsnotify.Create && event.Op != fsnotify.Rename {
 				continue
 			}
 			w.ch <- &event

--- a/main.go
+++ b/main.go
@@ -183,6 +183,7 @@ func main() {
 								}
 								logger.Error(err, "Error monitoring watcher interface.")
 							}
+							logger.V(1).Info("Starting new workflow", "watcher", event.WatcherName, "bucket", event.Bucket, "key", event.Key)
 							go func() {
 								if err := collection.InitProcessingWorkflow(ctx, workflowClient, event); err != nil {
 									logger.Error(err, "Error initializing processing workflow.")


### PR DESCRIPTION
This pull request introduces two changes that help us work with watched directories when the transfers are ~too~ big (see #41 for more details).
* We've updated filenotify so the poller (filesystem watcher when inotify is unavailable) subscribes to rename events. The inotify implementation was already doing that so no changes were required.
* Additionally, we've added a new configuration attribute `[[watcher.filesystem]] ignore` (only relevant to fs watchers) to ignore events where the names don't match the defined regular expression. It uses the stdlib [regex](https://golang.org/pkg/regexp/) package and it matches strings using the [`MatchString`](https://godoc.org/regexp#MatchString) method.

For example, the watcher below will ignore files with extension ".mft". E.g. file "package.mft" is being transferred and takes a few minutes to complete, later it's renamed as "package.tar". Enduro won't start the workflow until the tar file is seen.

```toml
[[watcher.filesystem]]
name = "dev-fs"
path = "./hack/watched-dir"
inotify = true
pipeline = "am"
retentionPeriod = "11s"
ignore = "^*\\.mft$"
stripTopLevelDir = true
```