### PR TITLE
Proposal: limit package flooding

### DIFF
--- a/internal/workflow/processing.go
+++ b/internal/workflow/processing.go
@@ -333,7 +333,7 @@ func (w *ProcessingWorkflow) SessionHandler(sessCtx workflow.Context, attempt in
 		if tinfo.TransferID == "" {
 			var transferResponse = activities.TransferActivityResponse{}
 
-			activityOpts := withActivityOptsForRequest(sessCtx)
+			activityOpts := withActivityOptsForHeartbeatedRequest(sessCtx, time.Minute)
 			err := workflow.ExecuteActivity(activityOpts, activities.TransferActivityName, &activities.TransferActivityParams{
 				PipelineName:       tinfo.Event.PipelineName,
 				TransferLocationID: tinfo.PipelineConfig.TransferLocationID,


### PR DESCRIPTION
This PR is an example to show how Enduro can use the transfer slot proposal of [#1579](https://github.com/artefactual/archivematica/pull/1579). The implementation is not very nice, or polished. But it's more to show how I see this, rather than something I would like so see merged. 

### General idea
The work in [#1579](https://github.com/artefactual/archivematica/pull/1579) basically changes the `package` end-point to return an error if you try to start too many transfers. I have changed the transfer activity in Enduro to a heartbeat activity that will try to create a new package as long as it takes to get a free slot. This way you can limit the number of activities in Enduro using the `capacity` semaphore, while you can limit the activity in Archivematica using `concurrent_packages` and `max_queued_transfers`. This allows for more fine-grained control of the utilization for each service and allows potentially for more efficient pipelining of transfers. I.e. Enduro can already prepare transfers while waiting for new transfer slots to be released.

### What will the user see?
Since a picture is worth 1000 words I will show the functionality using a picture story. For my example, I have used an Enduro instance with a `capacity` of 4, while my Archivematica instance has 2 transfer slots available and will process 1 package concurrently. 

First I moved 6 transfers to the watched directory. As expected Enduro starts 6 jobs, 4 are immediately started and 2 are queued:
![image](https://user-images.githubusercontent.com/7934339/75383335-7360e200-58dc-11ea-9e96-62395de18c95.png)

The first jobs have a very typical Activity summary: the (small) transfer is started within seconds:
![image](https://user-images.githubusercontent.com/7934339/75383359-7e1b7700-58dc-11ea-972b-eb4c5e668414.png)

The later jobs have no transfer slot available and need to wait before they can pass the transfer stage:
![image](https://user-images.githubusercontent.com/7934339/75383418-968b9180-58dc-11ea-86a1-b71e33365bc6.png)

After some time a transfer slot becomes available. In this example, we had to wait 25 seconds before the transfer could be submitted to Archivematica:
![image](https://user-images.githubusercontent.com/7934339/75383482-b458f680-58dc-11ea-9e60-a1d1cc9cec60.png)

Once some of the earlier transfers are done Enduro starts queueing the rest:
![image](https://user-images.githubusercontent.com/7934339/75383510-be7af500-58dc-11ea-91ce-317ee58d54fe.png)

And finally, everything is done:
![image](https://user-images.githubusercontent.com/7934339/75383698-203b5f00-58dd-11ea-9aa3-ffdee2bef232.png)

@sevein I know you have been working on how to handle workflows etc. I wonder what you think of this, and if it will fit within the ideas you guys have for workflow handling.
