### PR TITLE
Fix coverage report

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,8 @@
 on:
-- push
-- pull_request
+  pull_request:
+  push:
+    branches:
+    - main
 name: Lint
 jobs:
   lint:

--- a/.github/workflows/mod.yml
+++ b/.github/workflows/mod.yml
@@ -1,6 +1,8 @@
 on:
-- push
-- pull_request
+  pull_request:
+  push:
+    branches:
+    - main
 name: Mod
 jobs:
   mod:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 on:
-- push
-- pull_request
+  pull_request:
+  push:
+    branches:
+    - main
 name: Test
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
     - name: Test
-      run: go test -race -coverprofile=covreport -covermode=atomic -v ./...
+      run: go test -race -coverprofile=covreport -covermode=atomic -coverpkg=$(./hack/coverpkgs.sh) -v ./...
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/hack/coverpkgs.sh
+++ b/hack/coverpkgs.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+curdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+cd ${curdir}/..
+
+#
+# List all packages relevant to coverage reporting.
+#
+# Usage example:
+#
+#  $ go test -race -coverprofile=covreport -covermode=atomic -coverpkg=$(hack/coverpkgs.sh) -v ./...
+#  $ go tool cover -func=html
+#
+
+go list ./... \
+	| grep -v "/artefactual-labs/enduro/hack" \
+	| grep -v "/artefactual-labs/enduro/internal/api/gen" \
+	| grep -v "/artefactual-labs/enduro/internal/api/design" \
+	| grep -v "/artefactual-labs/enduro/ui" \
+	| grep -v "/fake" \
+	| paste -sd","


### PR DESCRIPTION
Measuring test coverage accurately requires ignoring certain packages that are
not under our control, e.g. generated code, tooling, etc... This commit uses
`go test -coverpkg` to ensure that coverage analysis is applied to packages
only matching the pattern given.