### PR TITLE
Unset WriteTimeout to allow streaming

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -85,10 +85,12 @@ func HTTPServer(
 	}
 
 	return &http.Server{
-		Addr:         config.Listen,
-		Handler:      handler,
-		ReadTimeout:  time.Second * 5,
-		WriteTimeout: time.Second * 10,
+		Addr:        config.Listen,
+		Handler:     handler,
+		ReadTimeout: time.Second * 5,
+		// WriteTimeout is set to 0 because we have streaming endpoints.
+		// https://github.com/golang/go/issues/16100#issuecomment-285573480
+		WriteTimeout: 0,
 		IdleTimeout:  time.Second * 120,
 	}
 }

--- a/internal/collection/download.go
+++ b/internal/collection/download.go
@@ -72,7 +72,7 @@ func (dp *downloadReverseProxy) modifyResponse(r *http.Response) error {
 func (dp *downloadReverseProxy) errorHandler(rw http.ResponseWriter, req *http.Request, err error) {
 	rw.WriteHeader(http.StatusInternalServerError)
 	fmt.Fprintf(rw, `{"message": "The operation failed unexpectedly. Contact the administrator for more details."}`)
-	dp.logger.Info("Download from Storage Service failed", "msg", err)
+	dp.logger.Info("Download from Storage Service failed", "msg", err.Error())
 }
 
 func (p *downloadReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
This is a potential fix for an error we've seen where file streaming stops abruptly. I believe we're exceeded the write timeout. Unfortunately, we can only set it for the whole server.

Connects to https://github.com/artefactual-labs/enduro/issues/255.