### PR TITLE
Update retry strategy when polling Status API

### DIFF
--- a/enduro.toml
+++ b/enduro.toml
@@ -48,6 +48,7 @@ processingConfig = "automated"
 # transferLocationID = "88f6b517-c0cc-411b-8abf-79544ce96f54"
 storageServiceURL = "http://test:test@127.0.0.1:62081"
 capacity = 3
+retryDeadline = "10m"
 
 [validation]
 checksumsCheckEnabled = false

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/jmoiron/sqlx v1.3.4
 	github.com/johejo/golang-migrate-extra v0.0.0-20210217013041-51a992e50d16
+	github.com/jonboulle/clockwork v0.2.2
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/magiconair/properties v1.8.4 // indirect
 	github.com/mholt/archiver/v3 v3.5.0

--- a/go.sum
+++ b/go.sum
@@ -608,6 +608,8 @@ github.com/johejo/golang-migrate-extra v0.0.0-20210217013041-51a992e50d16 h1:sDj
 github.com/johejo/golang-migrate-extra v0.0.0-20210217013041-51a992e50d16/go.mod h1:lzH77MbyyahK7YO90wGRb65i9xLSoy2fD0dUSm23yMs=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/jonboulle/clockwork v0.2.2 h1:UOGuzwb1PwsrDAObMuhUnj0p5ULPj8V/xJ7Kx9qUBdQ=
+github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -30,6 +30,7 @@ type Config struct {
 	ProcessingConfig   string
 	StorageServiceURL  string
 	Capacity           uint64
+	RetryDeadline      *time.Duration
 }
 
 type Pipeline struct {

--- a/internal/workflow/activities/poll.go
+++ b/internal/workflow/activities/poll.go
@@ -1,0 +1,20 @@
+package activities
+
+import (
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/jonboulle/clockwork"
+)
+
+var (
+	// Our default back-off strategy when polling.
+	backoffStrategy backoff.BackOff = backoff.NewConstantBackOff(time.Second * 5)
+
+	// Default deadline when retrying on errors, e.g. HTTP 5xx. Users can
+	// override with retryDeadline, a pipeline configuration attribute.
+	defaultMaxElapsedTime = time.Minute * 10
+
+	// System clock.
+	clock clockwork.Clock = clockwork.NewRealClock()
+)

--- a/internal/workflow/activities/poll_ingest_test.go
+++ b/internal/workflow/activities/poll_ingest_test.go
@@ -1,0 +1,146 @@
+package activities
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/artefactual-labs/enduro/internal/pipeline"
+	"github.com/go-logr/logr"
+	"github.com/jonboulle/clockwork"
+	"go.uber.org/cadence/testsuite"
+	"go.uber.org/cadence/worker"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestPollIngestActivity(t *testing.T) {
+	t.Run("Fails when the pipeline isn't found", func(t *testing.T) {
+		manager := newManager(t, nil)
+		activity := NewPollIngestActivity(manager)
+		manager.Pipelines, _ = pipeline.NewPipelineRegistry(logr.Discard(), []pipeline.Config{})
+
+		s := testsuite.WorkflowTestSuite{}
+		env := s.NewTestActivityEnvironment()
+		env.RegisterActivity(activity.Execute)
+
+		future, err := env.ExecuteActivity(activity.Execute, &PollIngestActivityParams{})
+
+		assert.Assert(t, is.Nil(future))
+		assert.Error(t, err, "non retryable error")
+	})
+
+	t.Run("Identifies packages that completed processing successfully", func(t *testing.T) {
+		ctx := context.Background()
+		now := time.Now()
+		clock = clockwork.NewFakeClockAt(now)
+		manager := newManager(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"sip_uuid": "734abbaf-4e2f-4a68-938c-c8ff6420e525",
+				"status": "COMPLETE"
+			}`))
+		})
+		activity := NewPollIngestActivity(manager)
+
+		s := testsuite.WorkflowTestSuite{}
+		env := s.NewTestActivityEnvironment()
+		env.RegisterActivity(activity.Execute)
+		env.SetWorkerOptions(worker.Options{BackgroundActivityContext: ctx})
+
+		var storedAt time.Time
+		future, err := env.ExecuteActivity(activity.Execute, &PollIngestActivityParams{
+			PipelineName: "am",
+			SIPID:        "734abbaf-4e2f-4a68-938c-c8ff6420e525",
+		})
+		future.Get(&storedAt)
+
+		assert.NilError(t, err)
+		assert.Equal(t, storedAt.Sub(now).String(), "0s")
+	})
+
+	t.Run("Abandons when a non-retryable error is detected", func(t *testing.T) {
+		ctx := context.Background()
+		manager := newManager(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		})
+		activity := NewPollIngestActivity(manager)
+
+		s := testsuite.WorkflowTestSuite{}
+		env := s.NewTestActivityEnvironment()
+		env.RegisterActivity(activity.Execute)
+		env.SetWorkerOptions(worker.Options{BackgroundActivityContext: ctx})
+
+		future, err := env.ExecuteActivity(activity.Execute, &PollIngestActivityParams{
+			PipelineName: "am",
+			SIPID:        "cbc4b312-b076-4ff7-b67b-b6850f2b4486",
+		})
+
+		assert.Assert(t, is.Nil(future))
+		assert.Error(t, err, "non retryable error")
+	})
+
+	t.Run("Polls until processing completes", func(t *testing.T) {
+		ctx := context.Background()
+		backoffStrategy = &ZeroBackOff{}
+		attempts := 0
+		manager := newManager(t, func(w http.ResponseWriter, r *http.Request) {
+			attempts++
+			if attempts > 3 {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{
+					"sip_uuid": "734abbaf-4e2f-4a68-938c-c8ff6420e525",
+					"status": "COMPLETE"
+				}`))
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"sip_uuid": "734abbaf-4e2f-4a68-938c-c8ff6420e525",
+				"status": "PROCESSING"
+			}`))
+		})
+		activity := NewPollIngestActivity(manager)
+
+		s := testsuite.WorkflowTestSuite{}
+		env := s.NewTestActivityEnvironment()
+		env.RegisterActivity(activity.Execute)
+		env.SetWorkerOptions(worker.Options{BackgroundActivityContext: ctx})
+
+		_, err := env.ExecuteActivity(activity.Execute, &PollIngestActivityParams{
+			PipelineName: "am",
+			SIPID:        "cbc4b312-b076-4ff7-b67b-b6850f2b4486",
+		})
+
+		assert.NilError(t, err)
+		assert.Equal(t, backoffStrategy.(*ZeroBackOff).hits, 3)
+	})
+
+	t.Run("Retries on retry-able errors until the deadline is exceeded", func(t *testing.T) {
+		ctx := context.Background()
+		backoffStrategy = &ZeroBackOff{}
+		clock = clockwork.NewFakeClock()
+		attempts := 0
+		manager := newManager(t, func(w http.ResponseWriter, r *http.Request) {
+			attempts++
+			clock.(clockwork.FakeClock).Advance(time.Minute)
+			w.WriteHeader(http.StatusBadGateway)
+		})
+		activity := NewPollIngestActivity(manager)
+
+		s := testsuite.WorkflowTestSuite{}
+		env := s.NewTestActivityEnvironment()
+		env.RegisterActivity(activity.Execute)
+		env.SetWorkerOptions(worker.Options{BackgroundActivityContext: ctx})
+
+		future, err := env.ExecuteActivity(activity.Execute, &PollIngestActivityParams{
+			PipelineName: "am",
+			SIPID:        "734abbaf-4e2f-4a68-938c-c8ff6420e525",
+		})
+
+		assert.Assert(t, is.Nil(future))
+		assert.Error(t, err, "non retryable error")
+		assert.Equal(t, backoffStrategy.(*ZeroBackOff).hits, 6)
+	})
+}

--- a/internal/workflow/activities/poll_test.go
+++ b/internal/workflow/activities/poll_test.go
@@ -1,0 +1,55 @@
+package activities
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/artefactual-labs/enduro/internal/pipeline"
+	"github.com/artefactual-labs/enduro/internal/workflow/manager"
+	"github.com/go-logr/logr"
+	"gotest.tools/v3/assert"
+)
+
+type ZeroBackOff struct {
+	hits int
+}
+
+func (b *ZeroBackOff) Reset() {}
+
+func (b *ZeroBackOff) NextBackOff() time.Duration {
+	b.hits++
+	return 0
+}
+
+func newManager(t *testing.T, h http.HandlerFunc) *manager.Manager {
+	t.Helper()
+	logger := logr.Discard()
+
+	mux := http.NewServeMux()
+	if h != nil {
+		mux.HandleFunc("/", h)
+	}
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(func() { server.Close() })
+
+	retryDeadline := time.Duration(time.Minute * 5)
+	pipelineURL, _ := url.Parse(server.URL)
+	pipelines, err := pipeline.NewPipelineRegistry(logger, []pipeline.Config{
+		{
+			ID:            "75ed5f0a-792e-4ce9-aeb7-e2e832d2a4fa",
+			Name:          "am",
+			BaseURL:       pipelineURL.String(),
+			RetryDeadline: &retryDeadline,
+		},
+	})
+	assert.NilError(t, err)
+
+	return &manager.Manager{
+		Logger:    logger,
+		Pipelines: pipelines,
+	}
+}

--- a/internal/workflow/activities/poll_transfer_test.go
+++ b/internal/workflow/activities/poll_transfer_test.go
@@ -1,0 +1,147 @@
+package activities
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/artefactual-labs/enduro/internal/pipeline"
+	"github.com/go-logr/logr"
+	"github.com/jonboulle/clockwork"
+	"go.uber.org/cadence/testsuite"
+	"go.uber.org/cadence/worker"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestPollTransferActivity(t *testing.T) {
+	t.Run("Fails when the pipeline isn't found", func(t *testing.T) {
+		manager := newManager(t, nil)
+		activity := NewPollTransferActivity(manager)
+		manager.Pipelines, _ = pipeline.NewPipelineRegistry(logr.Discard(), []pipeline.Config{})
+
+		s := testsuite.WorkflowTestSuite{}
+		env := s.NewTestActivityEnvironment()
+		env.RegisterActivity(activity.Execute)
+
+		future, err := env.ExecuteActivity(activity.Execute, &PollTransferActivityParams{})
+
+		assert.Assert(t, is.Nil(future))
+		assert.Error(t, err, "non retryable error")
+	})
+
+	t.Run("Identifies packages that completed processing successfully", func(t *testing.T) {
+		ctx := context.Background()
+		manager := newManager(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"sip_uuid": "734abbaf-4e2f-4a68-938c-c8ff6420e525",
+				"status": "COMPLETE"
+			}`))
+		})
+		activity := NewPollTransferActivity(manager)
+
+		s := testsuite.WorkflowTestSuite{}
+		env := s.NewTestActivityEnvironment()
+		env.RegisterActivity(activity.Execute)
+		env.SetWorkerOptions(worker.Options{BackgroundActivityContext: ctx})
+
+		var sipID string
+		future, err := env.ExecuteActivity(activity.Execute, &PollTransferActivityParams{
+			PipelineName: "am",
+			TransferID:   "cbc4b312-b076-4ff7-b67b-b6850f2b4486",
+		})
+		future.Get(&sipID)
+
+		assert.NilError(t, err)
+		assert.Equal(t, sipID, "734abbaf-4e2f-4a68-938c-c8ff6420e525")
+	})
+
+	t.Run("Abandons when a non-retryable error is detected", func(t *testing.T) {
+		ctx := context.Background()
+		manager := newManager(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		})
+		activity := NewPollTransferActivity(manager)
+
+		s := testsuite.WorkflowTestSuite{}
+		env := s.NewTestActivityEnvironment()
+		env.RegisterActivity(activity.Execute)
+		env.SetWorkerOptions(worker.Options{BackgroundActivityContext: ctx})
+
+		future, err := env.ExecuteActivity(activity.Execute, &PollTransferActivityParams{
+			PipelineName: "am",
+			TransferID:   "cbc4b312-b076-4ff7-b67b-b6850f2b4486",
+		})
+
+		assert.Assert(t, is.Nil(future))
+		assert.Error(t, err, "non retryable error")
+	})
+
+	t.Run("Polls until processing completes", func(t *testing.T) {
+		ctx := context.Background()
+		backoffStrategy = &ZeroBackOff{}
+		attempts := 0
+		manager := newManager(t, func(w http.ResponseWriter, r *http.Request) {
+			attempts++
+			if attempts > 3 {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{
+					"sip_uuid": "734abbaf-4e2f-4a68-938c-c8ff6420e525",
+					"status": "COMPLETE"
+				}`))
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"sip_uuid": "734abbaf-4e2f-4a68-938c-c8ff6420e525",
+				"status": "PROCESSING"
+			}`))
+		})
+		activity := NewPollTransferActivity(manager)
+
+		s := testsuite.WorkflowTestSuite{}
+		env := s.NewTestActivityEnvironment()
+		env.RegisterActivity(activity.Execute)
+		env.SetWorkerOptions(worker.Options{BackgroundActivityContext: ctx})
+
+		var sipID string
+		future, err := env.ExecuteActivity(activity.Execute, &PollTransferActivityParams{
+			PipelineName: "am",
+			TransferID:   "cbc4b312-b076-4ff7-b67b-b6850f2b4486",
+		})
+		future.Get(&sipID)
+
+		assert.NilError(t, err)
+		assert.Equal(t, sipID, "734abbaf-4e2f-4a68-938c-c8ff6420e525")
+		assert.Equal(t, backoffStrategy.(*ZeroBackOff).hits, 3)
+	})
+
+	t.Run("Retries on retry-able errors until the deadline is exceeded", func(t *testing.T) {
+		ctx := context.Background()
+		backoffStrategy = &ZeroBackOff{}
+		clock = clockwork.NewFakeClock()
+		attempts := 0
+		manager := newManager(t, func(w http.ResponseWriter, r *http.Request) {
+			attempts++
+			clock.(clockwork.FakeClock).Advance(time.Minute)
+			w.WriteHeader(http.StatusBadGateway)
+		})
+		activity := NewPollTransferActivity(manager)
+
+		s := testsuite.WorkflowTestSuite{}
+		env := s.NewTestActivityEnvironment()
+		env.RegisterActivity(activity.Execute)
+		env.SetWorkerOptions(worker.Options{BackgroundActivityContext: ctx})
+
+		future, err := env.ExecuteActivity(activity.Execute, &PollTransferActivityParams{
+			PipelineName: "am",
+			TransferID:   "cbc4b312-b076-4ff7-b67b-b6850f2b4486",
+		})
+
+		assert.Assert(t, is.Nil(future))
+		assert.Error(t, err, "non retryable error")
+		assert.Equal(t, backoffStrategy.(*ZeroBackOff).hits, 6)
+	})
+}


### PR DESCRIPTION
This commit updates the retry strategy when polling the Status API:

* 4xx client errors are now considered non-retryable, and
* 5xx server errors will be retried with a delayy of five seconds, and a
  deadline of five minutes, and
* 400 status code, which the Archivematica API chooses to send when
  raising a type o known server error (i.e. no jobs), will be retried as
  we do with 5xx errors.

Fixes https://github.com/artefactual-labs/enduro/issues/282.