### PR TITLE
Update tests for NHA receipts

### DIFF
--- a/internal/nha/activities/prod_test.go
+++ b/internal/nha/activities/prod_test.go
@@ -53,7 +53,7 @@ func TestProdActivity(t *testing.T) {
 					"file": "objects/DPJ/journal/avlxml.xml",
 					"identifiers": [{
 						"identifierType": "avleveringsidentifikator",
-						"identifier": "12345"
+						"identifier": "3.15.578.1.39.120.11.9896.12"
 					}]
 				}]`),
 			},
@@ -63,7 +63,7 @@ func TestProdActivity(t *testing.T) {
   "accepted": true,
   "message": "Package was processed by Archivematica pipeline foo-bar-001",
   "timestamp": "2009-11-10T23:00:00Z",
-  "parent": "12345"
+  "parent": "3.15.578.1.39.120.11.9896.12"
 }
 `,
 		},
@@ -72,7 +72,7 @@ func TestProdActivity(t *testing.T) {
 				StoredAt:     time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
 				PipelineName: "foo-bar-001",
 				NameInfo: nha.NameInfo{
-					Identifier: "aa1df25d-1477-4085-8be3-a17fed20f843",
+					Identifier: "3.15.578.1.39.120.11.9896.12",
 					Type:       nha.TransferTypeAVLXML,
 				},
 			},
@@ -81,7 +81,7 @@ func TestProdActivity(t *testing.T) {
 				fs.WithFile("DPJ/journal/avlxml.xml", "<xml/>"),
 			},
 			wantContent: `{
-  "identifier": "aa1df25d-1477-4085-8be3-a17fed20f843",
+  "identifier": "3.15.578.1.39.120.11.9896.12",
   "type": "avlxml",
   "accepted": true,
   "message": "Package was processed by Archivematica pipeline foo-bar-001",


### PR DESCRIPTION
 - Use OID as parent field for dpj/epj
 - Use OID as avlxml identifier