### PR TITLE
Show AIPID as soon as it's available

### DIFF
--- a/ui/src/views/CollectionShow.vue
+++ b/ui/src/views/CollectionShow.vue
@@ -52,7 +52,7 @@
           <dd>{{ collection.transferId }}</dd>
         </template>
 
-        <template v-if="collection.status == 'done' && collection.aipId">
+        <template v-if="collection.aipId">
           <dt>AIP</dt>
           <dd>{{ collection.aipId }}</dd>
         </template>


### PR DESCRIPTION
This also ensures that the identifier is shown even if the workflow failed.

Fixes https://github.com/artefactual-labs/enduro/issues/394.