### PR TITLE
NHA: Update to avlxml version 3

### DIFF
--- a/internal/nha/activities/hari.go
+++ b/internal/nha/activities/hari.go
@@ -277,7 +277,7 @@ func (t avlRequestTime) MarshalJSON() ([]byte, error) {
 }
 
 // avlxml is the trimmed version of AVLXML, not including `pasientjournal`.
-// Schemas here: https://github.com/arkivverket/schemas/tree/master/AVLXML/.
+// Schemas here: https://github.com/norsk-helsearkiv/avlxml/tree/master.
 type avlxml struct {
 	XMLName                  xml.Name
 	XSI                      XmlnsAttr `xml:"xsi,attr"`
@@ -285,6 +285,7 @@ type avlxml struct {
 	Avlxmlversjon            string    `xml:"avlxmlversjon"`
 	Avleveringsidentifikator string    `xml:"avleveringsidentifikator"`
 	Avleveringsbeskrivelse   string    `xml:"avleveringsbeskrivelse"`
+	Generertdato             string    `xml:"generertdato"`
 	Arkivskaper              string    `xml:"arkivskaper"`
 	Avtale                   struct {
 		InnerXML string `xml:",innerxml"`

--- a/internal/nha/activities/hari_test.go
+++ b/internal/nha/activities/hari_test.go
@@ -36,7 +36,7 @@ func TestHARIActivity(t *testing.T) {
 
 	// When slimDown is used.
 	emptyavlxml := []byte(`<?xml version="1.0" encoding="UTF-8"?>
-<avlxml xmlns:xsi="" xsi:schemaLocation=""><avlxmlversjon></avlxmlversjon><avleveringsidentifikator></avleveringsidentifikator><avleveringsbeskrivelse></avleveringsbeskrivelse><arkivskaper></arkivskaper><avtale></avtale></avlxml>`)
+<avlxml xmlns:xsi="" xsi:schemaLocation=""><avlxmlversjon></avlxmlversjon><avleveringsidentifikator></avleveringsidentifikator><avleveringsbeskrivelse></avleveringsbeskrivelse><generertdato></generertdato><arkivskaper></arkivskaper><avtale></avtale></avlxml>`)
 
 	tests := map[string]struct {
 		// Activity parameters.


### PR DESCRIPTION
Later versions of avlxml include an optional tag 'generertdato':
```
  <xs:complexType name="avlevering">
    <xs:annotation>
      <xs:documentation>Avleveringslisten i AVLXML</xs:documentation>
    </xs:annotation>
    <xs:sequence>
      <xs:element name="avlxmlversjon" type="avlmdk:avlxmlversjon"/>
      <xs:element name="avleveringsidentifikator" type="avlmdk:avleveringsidentifikator"/>
      <xs:element name="avleveringsbeskrivelse" type="avlmdk:avleveringsbeskrivelse"/>
      <xs:element minOccurs="0" name="generertdato" type="avlmdk:arkDATO"/>
      <xs:element name="arkivskaper" type="avlmdk:arkivskaper"/>
      <xs:element name="avtale" type="avtale"/>
      <xs:element maxOccurs="unbounded" name="pasientjournal" type="pasientjournal"/>
    </xs:sequence>
  </xs:complexType>
```
If it exists in the AVLXML inside an ingested avl-sip, it should be sent to HARI and let it be handled there. Currently, the AVLXML is stripped to get rid of patient journals and apparently the "generertdato" is stripped off at the same time.

NOTE: I am not certain this fix is correct, as I don't have a setup to build and test enduro. If the tag exists, I'm quite sure it is correct, but I could not figure out what would happen if it doesn't. Most likely, the xml decoder just skips it, and all is good. 