### PR TITLE
Disable Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: weekly


### PR DESCRIPTION
We pay close attention to Dependabot alerts and Dependabot security updates but plain version updates are rather too verbose and we manage using command-line toos like gomajor, npm-check-updates, etc...