### PR TITLE
Update hugo from 0.113.0 to 0.115.3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "website/themes/docsy"]
-	path = website/themes/docsy
-	url = https://github.com/google/docsy.git

--- a/hack/make/dep_hugo.mk
+++ b/hack/make/dep_hugo.mk
@@ -5,7 +5,7 @@ $(call _assert_var,UNAME_ARCH2)
 $(call _assert_var,CACHE_VERSIONS)
 $(call _assert_var,CACHE_BIN)
 
-HUGO_VERSION ?= 0.115.2
+HUGO_VERSION ?= 0.115.3
 
 HUGO := $(CACHE_VERSIONS)/hugo/$(HUGO_VERSION)
 $(HUGO):

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,32 +1,32 @@
 [build]
 base = "website"
 publish = "public"
-command = "git submodule update --init --recursive && hugo --gc --minify"
+command = "hugo --gc --minify"
 ignore = "cd ..; git diff --quiet HEAD^ HEAD ./website ./internal/api/gen/http/openapi.json"
 
 [context.split1]
-command = "git submodule update --init --recursive && hugo --gc --minify --enableGitInfo"
+command = "hugo --gc --minify --enableGitInfo"
 
 [context.split1.environment]
-HUGO_VERSION = "0.113.0"
+HUGO_VERSION = "0.115.3"
 HUGO_ENV = "production"
 
 [context.deploy-preview]
-command = "git submodule update --init --recursive && hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
+command = "hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
 
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.113.0"
+HUGO_VERSION = "0.115.3"
 
 [context.branch-deploy]
-command = "git submodule update --init --recursive && hugo --gc --minify -b $DEPLOY_PRIME_URL"
+command = "hugo --gc --minify -b $DEPLOY_PRIME_URL"
 
 [context.branch-deploy.environment]
-HUGO_VERSION = "ç"
+HUGO_VERSION = "0.115.3"
 
 [context.next.environment]
 HUGO_ENABLEGITINFO = "true"
 
 [context.production.environment]
-HUGO_VERSION = "0.113.0"
+HUGO_VERSION = "0.115.3"
 HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"

--- a/website/config.toml
+++ b/website/config.toml
@@ -4,7 +4,7 @@ title = "Enduro"
 enableRobotsTXT = true
 
 # Hugo allows theme composition (and inheritance). The precedence is from left to right.
-theme = ["docsy"]
+theme = ["github.com/google/docsy", "github.com/google/docsy/dependencies"]
 
 # Will give values to .Lastmod etc.
 enableGitInfo = true

--- a/website/content/en/docs/development/deps.md
+++ b/website/content/en/docs/development/deps.md
@@ -28,8 +28,7 @@ Use `npm run deps-minor` to install available updates.
 
 The version of Hugo is in `netlify.toml` and `hack/make/dep_hugo.mk`.
 
-Docsy is the Hugo theme (`website/themes/docsy`), installed as a submodule.
-We're still using v0.6.0 until we can address the update to Bootstrap 5.2.
+Docsy is the Hugo theme (`website/themes/docsy`), installed as a Hugo module.
 
 ## Other tools
 

--- a/website/content/en/docs/installation/_index.md
+++ b/website/content/en/docs/installation/_index.md
@@ -29,10 +29,9 @@ We use MySQL 8, which serves as the data store for Enduro and Temporal.
 
 ### Temporal
 
-Temporal is the orchestration engine. There are [multiple ways to run a Temporal
-Cluster](temporal-clusters). Our standard configuration uses an [Ansible
-role](temporal-ansible-role) to deploy both Enduro and Temporal on a remote
-server.
+Temporal is the orchestration engine. There are
+[multiple ways to run a Temporal Cluster]. Our standard configuration uses an
+[Ansible role] to deploy both Enduro and Temporal on a remote server.
 
 More on this topic can be found at the official [Temporal Cluster deployment
 guide](temporal-deployment).
@@ -107,8 +106,8 @@ the API via cURL is `curl -Ls 127.0.0.1:9000/collection | jq`:
 ]
 ```
 
-[temporal-clusters]: https://docs.temporal.io/kb/all-the-ways-to-run-a-cluster
-[temporal-ansible-role]: https://github.com/artefactual-labs/ansible-enduro-temporal
+[multiple ways to run a Temporal Cluster]: https://docs.temporal.io/kb/all-the-ways-to-run-a-cluster
+[Ansible role]: https://github.com/artefactual-labs/ansible-enduro-temporal
 [temporal-deployment]: https://docs.temporal.io/cluster-deployment-guide
 [temporal-web-ui]: https://docs.temporal.io/web-ui
 [minio-redis-access]: https://docs.min.io/docs/minio-bucket-notification-guide.html#Redis

--- a/website/go.mod
+++ b/website/go.mod
@@ -1,0 +1,5 @@
+module github.com/artefactual-labs/enduro/website
+
+go 1.20
+
+require github.com/google/docsy v0.7.1 // indirect

--- a/website/go.sum
+++ b/website/go.sum
@@ -1,0 +1,8 @@
+github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.7.0 h1:JaeZ0/KufX/BJ3SyATb/fmZa1DFI7o5d9KU+i6+lLJY=
+github.com/google/docsy v0.7.0/go.mod h1:5WhIFchr5BfH6agjcInhpLRz7U7map0bcmKSpcrg6BE=
+github.com/google/docsy v0.7.1 h1:DUriA7Nr3lJjNi9Ulev1SfiG1sUYmvyDeU4nTp7uDxY=
+github.com/google/docsy v0.7.1/go.mod h1:JCmE+c+izhE0Rvzv3y+AzHhz1KdwlA9Oj5YBMklJcfc=
+github.com/google/docsy/dependencies v0.7.0/go.mod h1:gihhs5gmgeO+wuoay4FwOzob+jYJVyQbNaQOh788lD4=
+github.com/google/docsy/dependencies v0.7.1/go.mod h1:gihhs5gmgeO+wuoay4FwOzob+jYJVyQbNaQOh788lD4=
+github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/website/layouts/swagger/list.html
+++ b/website/layouts/swagger/list.html
@@ -1,0 +1,23 @@
+{{ define "main" }}
+<div class="td-content">
+	<h1>{{ .Title }}</h1>
+	{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
+	<header class="article-meta">
+		{{ partial "taxonomy_terms_article_wrapper.html" . -}}
+		{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) -}}
+			{{ partial "reading-time.html" . -}}
+		{{ end -}}
+	</header>
+	{{ .Content }}
+  {{ partial "section-index.html" . -}}
+	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) -}}
+		{{ partial "feedback.html" .Site.Params.ui.feedback -}}
+		<br />
+	{{ end -}}
+	{{ if (.Site.DisqusShortname) -}}
+		<br />
+		{{ partial "disqus-comment.html" . -}}
+	{{ end -}}
+	{{ partial "page-meta-lastmod.html" . -}}
+</div>
+{{ end -}}

--- a/website/package.json
+++ b/website/package.json
@@ -3,9 +3,6 @@
   "version": "0.0.1",
   "description": "Enduro website.",
   "main": "none.js",
-  "scripts": {
-    "prepare": "cd themes/docsy && npm install"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/artefactual-labs/enduro.git"


### PR DESCRIPTION
hugo now uses its own modules system so we don't need to import docsy using
git submodules.
