### PR TITLE
Bump Github actions/setup-go from v4 to v5

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
         id: go_version
         run: echo "go_version=$(cat .go-version)" >> $GITHUB_OUTPUT
       - name: Install Go (${{ steps.go_version.outputs.go_version }})
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ steps.go_version.outputs.go_version }}
           cache: false

--- a/.github/workflows/mod.yml
+++ b/.github/workflows/mod.yml
@@ -14,7 +14,7 @@ jobs:
         id: go_version
         run: echo "go_version=$(cat .go-version)" >> $GITHUB_OUTPUT
       - name: Install Go (${{ steps.go_version.outputs.go_version }})
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ steps.go_version.outputs.go_version }}
       - name: Check go.mod

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,7 +17,7 @@ jobs:
         id: go_version
         run: echo "go_version=$(cat .go-version)" >> $GITHUB_OUTPUT
       - name: Install Go (${{ steps.go_version.outputs.go_version }})
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ steps.go_version.outputs.go_version }}
       - name: Install govulncheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         id: go_version
         run: echo "go_version=$(cat .go-version)" >> $GITHUB_OUTPUT
       - name: Install Go (${{ steps.go_version.outputs.go_version }})
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ steps.go_version.outputs.go_version }}
       - name: Install Node

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         id: go_version
         run: echo "go_version=$(cat .go-version)" >> $GITHUB_OUTPUT
       - name: Install Go (${{ steps.go_version.outputs.go_version }})
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ steps.go_version.outputs.go_version }}
       - name: Test


### PR DESCRIPTION
Fixes a Github actions error:

```
Node.js 16 actions are deprecated. Please update the following actions
to use Node.js 20: actions/setup-go@v4.
```