### PR TITLE
Fix gosec issues

### DIFF
--- a/internal/workflow/processing.go
+++ b/internal/workflow/processing.go
@@ -292,7 +292,7 @@ func (w *ProcessingWorkflow) Execute(ctx temporalsdk_workflow.Context, req *coll
 				}
 			}
 			src := rand.NewSource(time.Now().UnixNano())
-			rnd := rand.New(src)
+			rnd := rand.New(src) // #nosec G404 -- not security sensitive.
 			return names[rnd.Intn(len(names))]
 		}).Get(&pick); err != nil {
 			return err

--- a/main.go
+++ b/main.go
@@ -330,7 +330,12 @@ func main() {
 			mux.Handle("/debug/pprof/heap", pprof.Handler("heap"))
 			mux.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
 
-			return http.Serve(ln, mux)
+			srv := &http.Server{
+				ReadTimeout:  5 * time.Second,
+				WriteTimeout: 5 * time.Second,
+				Handler:      mux,
+			}
+			return srv.Serve(ln)
 		}, func(error) {
 			ln.Close()
 		})


### PR DESCRIPTION
Fix a couple of gosec warnings:
- G404: Insecure random number source (rand)
- G114: Use of net/http serve function that has no support for setting timeouts

I meant to go further and address the many "G304: Potential file inclusion via variable" gosec issues, but I'm not clear how to ensure path safety without potentially breaking current deployments.