### PR TITLE
Clean up files in processingDir (temporary staging dir)

### DIFF
--- a/internal/workflow/activities/cleanup.go
+++ b/internal/workflow/activities/cleanup.go
@@ -14,16 +14,18 @@ func NewCleanUpActivity() *CleanUpActivity {
 }
 
 type CleanUpActivityParams struct {
-	FullPath string
+	Paths []string
 }
 
 func (a *CleanUpActivity) Execute(ctx context.Context, params *CleanUpActivityParams) error {
-	if params == nil || params.FullPath == "" {
-		return fmt.Errorf("error processing parameters: missing or empty")
+	if params == nil {
+		return fmt.Errorf("error processing parameters: missing")
 	}
 
-	if err := os.RemoveAll(params.FullPath); err != nil {
-		return fmt.Errorf("error removing transfer directory: %v", err)
+	for _, p := range params.Paths {
+		if err := os.RemoveAll(p); err != nil {
+			return fmt.Errorf("error removing path: %v", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This PR will fix an issue where the files created in the `processingDir` (when configured in the pipeline) were never cleaned up by Enduro.

It also changes the (Temporal) context that the `clean-up` activity uses to a disconnected one, this avoids the (unintended) cancellation of the context when the session gets released.