### PR TITLE
Fix dates in Workflow tab

### DIFF
--- a/ui/src/filters/index.ts
+++ b/ui/src/filters/index.ts
@@ -7,10 +7,11 @@ export interface EventTime {
   nanos: number
 }
 
-Vue.filter('formatDateTimeString', (value: string | EventTime): Date => {
-    return typeof(value) === 'string'
+Vue.filter('formatDateTimeString', (value: string | EventTime): String => {
+    const date =  typeof(value) === 'string'
         ? new Date(value)
         : fromEventTimeToDate(value);
+    return date.toLocaleString();
 });
 
 Vue.filter('formatDateTime', (value: Date) => {

--- a/ui/src/filters/index.ts
+++ b/ui/src/filters/index.ts
@@ -7,14 +7,10 @@ export interface EventTime {
   nanos: number
 }
 
-Vue.filter('formatDateTimeString', (value: string | EventTime) => {
-  if (typeof(value) === 'object') {
-     value = value as EventTime
-     const date = fromEventTimeToDate(value);
-    return date.toLocaleString();
-  }
-  const date = new Date(value);
-  return date.toLocaleString();
+Vue.filter('formatDateTimeString', (value: string | EventTime): Date => {
+    return typeof(value) === 'string'
+        ? new Date(value)
+        : fromEventTimeToDate(value);
 });
 
 Vue.filter('formatDateTime', (value: Date) => {

--- a/ui/src/filters/index.ts
+++ b/ui/src/filters/index.ts
@@ -2,7 +2,17 @@ import Vue from 'vue';
 import moment from 'moment';
 import humanizeDuration from 'humanize-duration';
 
-Vue.filter('formatDateTimeString', (value: string) => {
+export interface EventTime {
+  seconds: number
+  nanos: number
+}
+
+Vue.filter('formatDateTimeString', (value: string | EventTime) => {
+  if (typeof(value) === 'object') {
+     value = value as EventTime
+     const date = fromEventTimeToDate(value);
+    return date.toLocaleString();
+  }
   const date = new Date(value);
   return date.toLocaleString();
 });
@@ -27,9 +37,15 @@ Vue.filter('formatDuration', (from: Date, to: Date) => {
   return humanizeDuration(moment.duration(diff).asMilliseconds());
 });
 
-Vue.filter('formatEpochDuration', (from: number, to: number) => {
-  const f = new Date(Math.round(from / 1000 / 1000));
-  const t = new Date(Math.round(to / 1000 / 1000));
+Vue.filter('formatEpochDuration', (from: EventTime, to: EventTime) => {
+  const f = fromEventTimeToDate(from)
+  const t = fromEventTimeToDate(to)
   const diff = moment(t).diff(f);
   return humanizeDuration(moment.duration(diff).asMilliseconds());
 });
+
+export function fromEventTimeToDate(ev :EventTime): Date {
+  let secondsToMilis = ev.seconds * 1000;
+  let nanosecondsToMilis = ev.nanos / 1_000_000;
+  return new Date(secondsToMilis + nanosecondsToMilis);
+}

--- a/ui/src/views/CollectionShowWorkflow.vue
+++ b/ui/src/views/CollectionShowWorkflow.vue
@@ -238,8 +238,8 @@ export default class CollectionShowWorkflow extends Vue {
   }
 
   private duration(startedAt: EventTime, completedAt: EventTime): string {
-    const started = new Date(fromEventTimeToDate(startedAt));
-    const completed = new Date(fromEventTimeToDate(completedAt));
+    const started = fromEventTimeToDate(startedAt);
+    const completed = fromEventTimeToDate(completedAt);
     const took = (completed.getTime() - started.getTime()) / 1000;
     return took.toLocaleString();
   }

--- a/ui/src/views/CollectionShowWorkflow.vue
+++ b/ui/src/views/CollectionShowWorkflow.vue
@@ -85,6 +85,7 @@ import { namespace } from 'vuex-class';
 import * as CollectionStore from '../store/collection';
 import CollectionStatusBadge from '@/components/CollectionStatusBadge.vue';
 import { api, EnduroCollectionClient } from '../client';
+import { EventTime, fromEventTimeToDate } from "@/filters";
 
 const collectionStoreNs = namespace('collection');
 
@@ -236,9 +237,9 @@ export default class CollectionShowWorkflow extends Vue {
     return desc
   }
 
-  private duration(startedAt: string, completedAt: string): string {
-    const started = new Date(startedAt);
-    const completed = new Date(completedAt);
+  private duration(startedAt: EventTime, completedAt: EventTime): string {
+    const started = new Date(fromEventTimeToDate(startedAt));
+    const completed = new Date(fromEventTimeToDate(completedAt));
     const took = (completed.getTime() - started.getTime()) / 1000;
     return took.toLocaleString();
   }


### PR DESCRIPTION
This MR fix the formatting for dates in the workflow Tab. At some point the Temporal payload for the event history changed and now we need to account for that.

This is how is looks right now: 
![image](https://github.com/user-attachments/assets/f6e7ec73-a69a-445c-9712-d51f048e06f3)

This is after the fix: 

![image](https://github.com/user-attachments/assets/3330af7e-4178-425a-bd17-c3a24f4eed93)

Fixes #628 
