### PR TITLE
Handle hide 409s as benign during recovery retries

### DIFF
--- a/internal/workflow/activities/hide_package.go
+++ b/internal/workflow/activities/hide_package.go
@@ -3,6 +3,9 @@ package activities
 import (
 	"context"
 	"fmt"
+	"net/http"
+
+	"go.artefactual.dev/amclient"
 
 	"github.com/artefactual-labs/enduro/internal/pipeline"
 	"github.com/artefactual-labs/enduro/internal/temporal"
@@ -16,7 +19,7 @@ func NewHidePackageActivity(pipelineRegistry *pipeline.Registry) *HidePackageAct
 	return &HidePackageActivity{pipelineRegistry: pipelineRegistry}
 }
 
-func (a *HidePackageActivity) Execute(ctx context.Context, unitID, unitType, pipelineName string) error {
+func (a *HidePackageActivity) Execute(ctx context.Context, unitID, unitType, pipelineName string, ignoreConflict bool) error {
 	p, err := a.pipelineRegistry.ByName(pipelineName)
 	if err != nil {
 		return temporal.NewNonRetryableError(err)
@@ -30,6 +33,9 @@ func (a *HidePackageActivity) Execute(ctx context.Context, unitID, unitType, pip
 	if unitType == "transfer" {
 		resp, _, err := amc.Transfer.Hide(ctx, unitID)
 		if err != nil {
+			if ignoreConflict && hideConflict(err) {
+				return nil
+			}
 			return fmt.Errorf("error hiding transfer: %v", err)
 		}
 		if !resp.Removed {
@@ -40,6 +46,9 @@ func (a *HidePackageActivity) Execute(ctx context.Context, unitID, unitType, pip
 	if unitType == "ingest" {
 		resp, _, err := amc.Ingest.Hide(ctx, unitID)
 		if err != nil {
+			if ignoreConflict && hideConflict(err) {
+				return nil
+			}
 			return fmt.Errorf("error hiding sip: %v", err)
 		}
 		if !resp.Removed {
@@ -48,4 +57,9 @@ func (a *HidePackageActivity) Execute(ctx context.Context, unitID, unitType, pip
 	}
 
 	return nil
+}
+
+func hideConflict(err error) bool {
+	amErr, ok := err.(*amclient.ErrorResponse)
+	return ok && amErr.Response != nil && amErr.Response.StatusCode == http.StatusConflict
 }

--- a/internal/workflow/activities/hide_package_test.go
+++ b/internal/workflow/activities/hide_package_test.go
@@ -1,0 +1,68 @@
+package activities
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"go.artefactual.dev/amclient"
+	"gotest.tools/v3/assert"
+)
+
+func TestHidePackageActivity(t *testing.T) {
+	t.Run("IgnoresConflictInRecoveryMode", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			unitType string
+			path     string
+		}{
+			{name: "transfer", unitType: "transfer", path: "/api/transfer/transfer-id/delete/"},
+			{name: "ingest", unitType: "ingest", path: "/api/ingest/ingest-id/delete/"},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				registry := newPipelineRegistry(t, func(w http.ResponseWriter, r *http.Request) {
+					switch r.URL.Path {
+					case "/api/v2beta/package/":
+						w.WriteHeader(http.StatusNotImplemented)
+						return
+					case tc.path:
+						w.WriteHeader(http.StatusConflict)
+						return
+					default:
+						http.NotFound(w, r)
+					}
+				})
+
+				activity := NewHidePackageActivity(registry)
+				err := activity.Execute(context.Background(), tc.unitType+"-id", tc.unitType, "am", true)
+				assert.NilError(t, err)
+			})
+		}
+	})
+
+	t.Run("ReturnsConflictOutsideRecoveryMode", func(t *testing.T) {
+		registry := newPipelineRegistry(t, func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/api/v2beta/package/":
+				w.WriteHeader(http.StatusNotImplemented)
+			case "/api/transfer/transfer-id/delete/":
+				w.WriteHeader(http.StatusConflict)
+			default:
+				http.NotFound(w, r)
+			}
+		})
+
+		activity := NewHidePackageActivity(registry)
+		err := activity.Execute(context.Background(), "transfer-id", "transfer", "am", false)
+		assert.ErrorContains(t, err, "error hiding transfer")
+	})
+}
+
+func TestHideConflict(t *testing.T) {
+	assert.Assert(t, hideConflict(&amclient.ErrorResponse{Response: &http.Response{StatusCode: http.StatusConflict}}))
+	assert.Assert(t, !hideConflict(&amclient.ErrorResponse{Response: &http.Response{StatusCode: http.StatusBadRequest}}))
+	assert.Assert(t, !hideConflict(errors.New("boom")))
+}

--- a/internal/workflow/processing.go
+++ b/internal/workflow/processing.go
@@ -398,11 +398,12 @@ func (w *ProcessingWorkflow) Execute(ctx temporalsdk_workflow.Context, req *coll
 		if status == collection.StatusDone {
 			futures := []temporalsdk_workflow.Future{}
 			activityOpts := withActivityOptsForRequest(ctx)
+			ignoreHideConflict := req.RetryMode == collection.RetryModeReconcileExistingAIP
 			if tinfo.TransferID != "" {
-				futures = append(futures, temporalsdk_workflow.ExecuteActivity(activityOpts, activities.HidePackageActivityName, tinfo.TransferID, "transfer", tinfo.PipelineName))
+				futures = append(futures, temporalsdk_workflow.ExecuteActivity(activityOpts, activities.HidePackageActivityName, tinfo.TransferID, "transfer", tinfo.PipelineName, ignoreHideConflict))
 			}
 			if tinfo.SIPID != "" {
-				futures = append(futures, temporalsdk_workflow.ExecuteActivity(activityOpts, activities.HidePackageActivityName, tinfo.SIPID, "ingest", tinfo.PipelineName))
+				futures = append(futures, temporalsdk_workflow.ExecuteActivity(activityOpts, activities.HidePackageActivityName, tinfo.SIPID, "ingest", tinfo.PipelineName, ignoreHideConflict))
 			}
 			for _, f := range futures {
 				_ = f.Get(activityOpts, nil)

--- a/internal/workflow/processing_test.go
+++ b/internal/workflow/processing_test.go
@@ -251,7 +251,7 @@ func (s *ProcessingWorkflowTestSuite) TestReconciliationRetryNotFoundFallsBackTo
 		return time.Time{}, nil
 	}, temporalsdk_activity.RegisterOptions{Name: activities.PollIngestActivityName})
 	s.env.RegisterActivityWithOptions(func(*activities.CleanUpActivityParams) error { return nil }, temporalsdk_activity.RegisterOptions{Name: activities.CleanUpActivityName})
-	s.env.RegisterActivityWithOptions(func(string, string, string) error { return nil }, temporalsdk_activity.RegisterOptions{Name: activities.HidePackageActivityName})
+	s.env.RegisterActivityWithOptions(func(string, string, string, bool) error { return nil }, temporalsdk_activity.RegisterOptions{Name: activities.HidePackageActivityName})
 
 	storedAt := time.Date(2026, time.March, 17, 9, 0, 0, 0, time.UTC)
 
@@ -358,8 +358,8 @@ func (s *ProcessingWorkflowTestSuite) TestReconciliationRetryNotFoundFallsBackTo
 		SIPID:        "new-aip-id",
 	}).Return(storedAt, nil).Once()
 	s.env.OnActivity(releasePipelineLocalActivity, mock.Anything, mock.Anything, "pipeline").Return(nil).Once()
-	s.env.OnActivity(activities.HidePackageActivityName, "new-transfer-id", "transfer", "pipeline").Return(nil).Once()
-	s.env.OnActivity(activities.HidePackageActivityName, "new-aip-id", "ingest", "pipeline").Return(nil).Once()
+	s.env.OnActivity(activities.HidePackageActivityName, "new-transfer-id", "transfer", "pipeline", true).Return(nil).Once()
+	s.env.OnActivity(activities.HidePackageActivityName, "new-aip-id", "ingest", "pipeline", true).Return(nil).Once()
 	s.env.OnActivity(updatePackageLocalActivity, mock.Anything, mock.Anything, mock.Anything, &updatePackageLocalActivityParams{
 		CollectionID: uint(12345),
 		Key:          "key",
@@ -477,8 +477,8 @@ func (s *ProcessingWorkflowTestSuite) TestReconciliationRetryCompleteDeliversRec
 		NameInfo:     nha.NameInfo{},
 		FullPath:     "/transfer-dir/key",
 	}).Return(nil).Once()
-	s.env.OnActivity(activities.HidePackageActivityName, "transfer-id", "transfer", "pipeline").Return(nil).Once()
-	s.env.OnActivity(activities.HidePackageActivityName, "aip-id", "ingest", "pipeline").Return(nil).Once()
+	s.env.OnActivity(activities.HidePackageActivityName, "transfer-id", "transfer", "pipeline", true).Return(nil).Once()
+	s.env.OnActivity(activities.HidePackageActivityName, "aip-id", "ingest", "pipeline", true).Return(nil).Once()
 	s.env.OnActivity(updatePackageLocalActivity, mock.Anything, mock.Anything, mock.Anything, &updatePackageLocalActivityParams{
 		CollectionID: uint(12345),
 		Key:          "key",
@@ -936,8 +936,8 @@ func (s *ProcessingWorkflowTestSuite) TestRecoveryEnabledReconcilesAfterSuccessf
 			params.AIPStoredAt.Equal(pollStoredAt)
 	})).Return(nil).Once()
 	s.env.OnActivity(releasePipelineLocalActivity, mock.Anything, mock.Anything, "pipeline").Return(nil).Once()
-	s.env.OnActivity(activities.HidePackageActivityName, "transfer-id", "transfer", "pipeline").Return(nil).Once()
-	s.env.OnActivity(activities.HidePackageActivityName, "aip-id", "ingest", "pipeline").Return(nil).Once()
+	s.env.OnActivity(activities.HidePackageActivityName, "transfer-id", "transfer", "pipeline", false).Return(nil).Once()
+	s.env.OnActivity(activities.HidePackageActivityName, "aip-id", "ingest", "pipeline", false).Return(nil).Once()
 	s.env.OnActivity(updatePackageLocalActivity, mock.Anything, mock.Anything, mock.Anything, &updatePackageLocalActivityParams{
 		CollectionID: uint(12345),
 		Key:          "key",
@@ -1093,8 +1093,8 @@ func (s *ProcessingWorkflowTestSuite) TestRecoveryEnabledRetriesIndeterminateAft
 	})).Return(nil).Once()
 
 	s.env.OnActivity(releasePipelineLocalActivity, mock.Anything, mock.Anything, "pipeline").Return(nil).Once()
-	s.env.OnActivity(activities.HidePackageActivityName, "transfer-id", "transfer", "pipeline").Return(nil).Once()
-	s.env.OnActivity(activities.HidePackageActivityName, "aip-id", "ingest", "pipeline").Return(nil).Once()
+	s.env.OnActivity(activities.HidePackageActivityName, "transfer-id", "transfer", "pipeline", false).Return(nil).Once()
+	s.env.OnActivity(activities.HidePackageActivityName, "aip-id", "ingest", "pipeline", false).Return(nil).Once()
 	s.env.OnActivity(updatePackageLocalActivity, mock.Anything, mock.Anything, mock.Anything, &updatePackageLocalActivityParams{
 		CollectionID: uint(12345),
 		Key:          "key",
@@ -1245,8 +1245,8 @@ func (s *ProcessingWorkflowTestSuite) TestRecoveryEnabledRetriesNotFoundAfterSuc
 			params.AIPStoredAt.Equal(pollStoredAt)
 	})).Return(nil).Once()
 	s.env.OnActivity(releasePipelineLocalActivity, mock.Anything, mock.Anything, "pipeline").Return(nil).Once()
-	s.env.OnActivity(activities.HidePackageActivityName, "transfer-id", "transfer", "pipeline").Return(nil).Once()
-	s.env.OnActivity(activities.HidePackageActivityName, "aip-id", "ingest", "pipeline").Return(nil).Once()
+	s.env.OnActivity(activities.HidePackageActivityName, "transfer-id", "transfer", "pipeline", false).Return(nil).Once()
+	s.env.OnActivity(activities.HidePackageActivityName, "aip-id", "ingest", "pipeline", false).Return(nil).Once()
 	s.env.OnActivity(updatePackageLocalActivity, mock.Anything, mock.Anything, mock.Anything, &updatePackageLocalActivityParams{
 		CollectionID: uint(12345),
 		Key:          "key",
@@ -1516,8 +1516,8 @@ func (s *ProcessingWorkflowTestSuite) TestRecoveryEnabledPromotesIngestFailureWh
 			params.AIPStoredAt.Format(time.RFC3339) == "2026-03-17T07:00:00Z"
 	})).Return(nil).Once()
 	s.env.OnActivity(releasePipelineLocalActivity, mock.Anything, mock.Anything, "pipeline").Return(nil).Once()
-	s.env.OnActivity(activities.HidePackageActivityName, "transfer-id", "transfer", "pipeline").Return(nil).Once()
-	s.env.OnActivity(activities.HidePackageActivityName, "aip-id", "ingest", "pipeline").Return(nil).Once()
+	s.env.OnActivity(activities.HidePackageActivityName, "transfer-id", "transfer", "pipeline", false).Return(nil).Once()
+	s.env.OnActivity(activities.HidePackageActivityName, "aip-id", "ingest", "pipeline", false).Return(nil).Once()
 	s.env.OnActivity(updatePackageLocalActivity, mock.Anything, mock.Anything, mock.Anything, &updatePackageLocalActivityParams{
 		CollectionID: uint(12345),
 		Key:          "key",
@@ -1669,8 +1669,8 @@ func (s *ProcessingWorkflowTestSuite) TestRecoveryEnabledRetriesNotFoundAfterIng
 			params.AIPStoredAt.Format(time.RFC3339) == "2026-03-17T07:00:00Z"
 	})).Return(nil).Once()
 	s.env.OnActivity(releasePipelineLocalActivity, mock.Anything, mock.Anything, "pipeline").Return(nil).Once()
-	s.env.OnActivity(activities.HidePackageActivityName, "transfer-id", "transfer", "pipeline").Return(nil).Once()
-	s.env.OnActivity(activities.HidePackageActivityName, "aip-id", "ingest", "pipeline").Return(nil).Once()
+	s.env.OnActivity(activities.HidePackageActivityName, "transfer-id", "transfer", "pipeline", false).Return(nil).Once()
+	s.env.OnActivity(activities.HidePackageActivityName, "aip-id", "ingest", "pipeline", false).Return(nil).Once()
 	s.env.OnActivity(updatePackageLocalActivity, mock.Anything, mock.Anything, mock.Anything, &updatePackageLocalActivityParams{
 		CollectionID: uint(12345),
 		Key:          "key",
@@ -1852,7 +1852,7 @@ func registerWorkflowActivityStubs(env *temporalsdk_testsuite.TestWorkflowEnviro
 		return time.Time{}, nil
 	}, temporalsdk_activity.RegisterOptions{Name: activities.PollIngestActivityName})
 	env.RegisterActivityWithOptions(func(*activities.CleanUpActivityParams) error { return nil }, temporalsdk_activity.RegisterOptions{Name: activities.CleanUpActivityName})
-	env.RegisterActivityWithOptions(func(string, string, string) error { return nil }, temporalsdk_activity.RegisterOptions{Name: activities.HidePackageActivityName})
+	env.RegisterActivityWithOptions(func(string, string, string, bool) error { return nil }, temporalsdk_activity.RegisterOptions{Name: activities.HidePackageActivityName})
 	env.RegisterActivityWithOptions(func(*nha_activities.UpdateHARIActivityParams) error { return nil }, temporalsdk_activity.RegisterOptions{Name: nha_activities.UpdateHARIActivityName})
 	env.RegisterActivityWithOptions(func(*nha_activities.UpdateProductionSystemActivityParams) error { return nil }, temporalsdk_activity.RegisterOptions{Name: nha_activities.UpdateProductionSystemActivityName})
 }


### PR DESCRIPTION
Recovery-only retries can now finish cleanly when Archivematica retries 409 Conflict from transfer or ingest hide calls. Enduro passes a recovery flag into hide-package-activity for reconcile_existing_aip runs and treats 409 as a non-fatal, idempotent cleanup outcome in that mode, while keeping normal ingest hides strict. Includes workflow test updates and new activity tests covering the recovery and non-recovery cases.