### PR TITLE
Allow cancelling queued collections

### DIFF
--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -71,6 +71,65 @@ configuration section](./configuration-reference.md#watcher) for more details.
   transfer remains visible in the transfer and/or ingest tabs (depending on
   which micro-service failed).
 
+## Collection status state machine
+
+Enduro collection statuses describe Enduro's view of the processing workflow.
+The normal lifecycle is `queued` -> `in progress` -> `done`. Operator actions
+and failures can move the collection into `pending`, `error`, or `abandoned`.
+The actions below describe normal dashboard behavior; lower-level API endpoints
+may accept a broader set of calls.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Queued: Workflow starts
+    Queued --> InProgress: Pipeline capacity acquired
+    Queued --> Abandoned: Cancel before Archivematica submission
+    Queued --> Error: Pre-processing failure
+    InProgress --> Pending: Operator decision required
+    Pending --> InProgress: Retry
+    Pending --> Abandoned: Abandon / decision timeout
+    Pending --> Error: Decision handling failure
+    InProgress --> Done: AIP stored successfully
+    InProgress --> Error: Processing failure
+    InProgress --> Abandoned: Cancel
+    Error --> Queued: Retry
+    Done --> [*]
+    Abandoned --> [*]
+```
+
+| Status | Meaning | Operator actions in the dashboard |
+| --- | --- | --- |
+| `queued` | Enduro has created the collection workflow, but the transfer has not started processing yet. It may be waiting for pipeline capacity. | Cancel is available when no Archivematica `transfer_id` has been assigned yet. Delete is not shown while the collection is still running. |
+| `in progress` | Enduro has acquired pipeline capacity and processing is underway. At this point the transfer may have been submitted to Archivematica. | Cancel is available. This stops Enduro's workflow, but it does not guarantee that already-submitted Archivematica work is stopped. Delete is not shown while the collection is still running. |
+| `pending` | Processing needs an operator decision before it can continue, usually after an activity failed and Enduro is waiting for retry or abandon. | Retry and Abandon are available from the pending decision controls. Delete is not shown while the collection is waiting for a decision. |
+| `done` | Processing completed successfully and the AIP was stored. | Delete is available. |
+| `error` | Processing failed and the workflow ended without a successful or operator-abandoned outcome. | Retry and Delete are available. Bulk Retry also targets collections in this state. |
+| `abandoned` | Processing was stopped by an operator decision or cancellation. | Delete is available. |
+| `new` | Reserved by the API but not used by the current processing workflow. | No normal dashboard action. |
+| `unknown` | Used when Enduro cannot map a status value to one of the known states. | Delete is available because the dashboard does not treat this as a running state. |
+
+The main transitions are:
+
+| From | To | Cause |
+| --- | --- | --- |
+| `queued` | `in progress` | Enduro acquires a pipeline capacity slot and starts the processing session. |
+| `queued` | `abandoned` | An operator cancels the collection before an Archivematica transfer ID is assigned. |
+| `queued` | `error` | The workflow fails before pipeline capacity is acquired, for example while checking duplicates, parsing metadata, loading configuration, or creating the processing session. |
+| `in progress` | `pending` | A workflow activity requires an operator decision before continuing. |
+| `pending` | `in progress` | An operator chooses Retry. |
+| `pending` | `abandoned` | An operator chooses Abandon, or the pending decision times out. |
+| `pending` | `error` | The decision path fails or receives an invalid decision value. |
+| `in progress` | `done` | Processing, ingest, and storage complete successfully. |
+| `in progress` | `error` | Processing fails without a successful or abandoned outcome. |
+| `in progress` | `abandoned` | An operator cancels the Enduro workflow. |
+| `error` | `queued` | An operator retries the collection, starting a new workflow run. |
+
+Cancel and Delete are different operations. Cancel asks Enduro to stop the
+processing workflow when possible. For queued collections that do not have an
+Archivematica transfer ID yet, canceling prevents submission to Archivematica.
+Delete removes the Enduro collection record and does not cancel processing that
+has already been started elsewhere.
+
 ## Pipeline capacity
 
 Pipeline capacity is the main operator-facing control for concurrent ingest

--- a/frontend/app/composables/useCollectionDetails.nuxt.spec.ts
+++ b/frontend/app/composables/useCollectionDetails.nuxt.spec.ts
@@ -2,8 +2,8 @@ import { defineComponent, h, ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
 
-import { RetryResultModeEnum } from '~/openapi-generator'
-import { useCollectionDetails } from './useCollectionDetails'
+import { EnduroDetailedStoredCollectionStatusEnum, RetryResultModeEnum } from '~/openapi-generator'
+import { canCancelCollection, useCollectionDetails } from './useCollectionDetails'
 
 const { navigateToMock } = vi.hoisted(() => ({
   navigateToMock: vi.fn()
@@ -108,5 +108,27 @@ describe('useCollectionDetails', () => {
     expect(navigateToMock).toHaveBeenCalledWith('/collections')
     expect(reloadCollectionData).toHaveBeenCalledTimes(3)
     expect(details.retryModeMessage.value).toBe('')
+  })
+
+  it('allows cancellation for queued collections before Archivematica submission', () => {
+    expect(canCancelCollection({
+      id: 1,
+      createdAt: new Date(),
+      status: EnduroDetailedStoredCollectionStatusEnum.Queued
+    })).toBe(true)
+
+    expect(canCancelCollection({
+      id: 1,
+      createdAt: new Date(),
+      status: EnduroDetailedStoredCollectionStatusEnum.Queued,
+      transferId: 'transfer-id'
+    })).toBe(false)
+
+    expect(canCancelCollection({
+      id: 1,
+      createdAt: new Date(),
+      status: EnduroDetailedStoredCollectionStatusEnum.InProgress,
+      transferId: 'transfer-id'
+    })).toBe(true)
   })
 })

--- a/frontend/app/composables/useCollectionDetails.ts
+++ b/frontend/app/composables/useCollectionDetails.ts
@@ -20,6 +20,16 @@ const RUNNING_STATUSES = new Set<EnduroDetailedStoredCollectionStatusEnum>([
   EnduroDetailedStoredCollectionStatusEnum.Pending
 ])
 
+export function canCancelCollection(collection: EnduroDetailedStoredCollection | null): boolean {
+  if (!collection) return false
+
+  if (collection.status === EnduroDetailedStoredCollectionStatusEnum.InProgress) {
+    return true
+  }
+
+  return collection.status === EnduroDetailedStoredCollectionStatusEnum.Queued && !collection.transferId
+}
+
 function createDefaultState(): CollectionDetailsState {
   return {
     activeAction: null,
@@ -172,7 +182,7 @@ export function useCollectionDetails() {
   })
   const canDelete = computed(() => Boolean(collection.value) && !isRunning.value)
   const canRetry = computed(() => collection.value?.status === EnduroDetailedStoredCollectionStatusEnum.Error)
-  const canCancel = computed(() => collection.value?.status === EnduroDetailedStoredCollectionStatusEnum.InProgress)
+  const canCancel = computed(() => canCancelCollection(collection.value))
 
   watch(() => monitor.recentEvents.value[0]?.receivedAt, () => {
     const latest = monitor.recentEvents.value[0]

--- a/hack/s3put/README.md
+++ b/hack/s3put/README.md
@@ -1,7 +1,7 @@
 # s3put
 
 `s3put` is a small test helper used by the Dagger object-storage smoke tests to
-upload one file to an S3-compatible endpoint.
+upload files to an S3-compatible endpoint.
 
 The helper exists so the smoke tests can exercise the same object-upload path
 against MinIO and SeaweedFS without depending on a provider-specific CLI such as
@@ -9,16 +9,16 @@ against MinIO and SeaweedFS without depending on a provider-specific CLI such as
 credentials, and a caller-provided endpoint, which matches the local object
 storage services started by Dagger.
 
-Build it from the repository root:
+Run it from the repository root:
 
 ```sh
-go build -trimpath -o /tmp/s3put ./hack/s3put
+go run ./hack/s3put -h
 ```
 
 Example:
 
 ```sh
-/tmp/s3put \
+go run ./hack/s3put \
   -endpoint http://127.0.0.1:9000 \
   -region us-west-1 \
   -bucket sips \
@@ -27,6 +27,37 @@ Example:
   -secret-key minio123 \
   -file ./transfer.zip
 ```
+
+Generate and upload one simple zipped transfer:
+
+```sh
+go run ./hack/s3put \
+  -endpoint http://127.0.0.1:7460 \
+  -region us-west-1 \
+  -bucket sips \
+  -key issue-681-single.zip \
+  -access-key minio \
+  -secret-key minio123 \
+  -generate-transfer
+```
+
+Generate and upload 25 simple zipped transfers:
+
+```sh
+go run ./hack/s3put \
+  -endpoint http://127.0.0.1:7460 \
+  -region us-west-1 \
+  -bucket sips \
+  -key-prefix issue-681 \
+  -count 25 \
+  -access-key minio \
+  -secret-key minio123 \
+  -generate-transfer
+```
+
+The multi-upload example creates object keys named `issue-681-001.zip`,
+`issue-681-002.zip`, and so on. This is useful when testing pipeline capacity
+and queued collection cancellation in the local Enduro development environment.
 
 The command exits with status `0` when the upload succeeds. Any validation,
 configuration, or upload failure is written to stderr and exits non-zero.

--- a/hack/s3put/main.go
+++ b/hack/s3put/main.go
@@ -1,10 +1,15 @@
 package main
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"os"
+	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -18,28 +23,34 @@ func main() {
 		region    = flag.String("region", "us-west-1", "S3 region")
 		bucket    = flag.String("bucket", "", "S3 bucket")
 		key       = flag.String("key", "", "S3 object key")
+		keyPrefix = flag.String("key-prefix", "transfer", "S3 object key prefix used for generated multi-upload keys")
 		accessKey = flag.String("access-key", "", "S3 access key")
 		secretKey = flag.String("secret-key", "", "S3 secret key")
 		path      = flag.String("file", "", "Path to the file to upload")
+		count     = flag.Int("count", 1, "Number of objects to upload")
+		generate  = flag.Bool("generate-transfer", false, "Generate a small zipped transfer instead of reading -file")
 	)
 	flag.Parse()
 
-	if *endpoint == "" || *bucket == "" || *key == "" || *accessKey == "" || *secretKey == "" || *path == "" {
-		fmt.Fprintln(os.Stderr, "endpoint, bucket, key, access-key, secret-key, and file are required")
+	if *endpoint == "" || *bucket == "" || *accessKey == "" || *secretKey == "" {
+		fmt.Fprintln(os.Stderr, "endpoint, bucket, access-key, and secret-key are required")
 		os.Exit(2)
 	}
-
-	file, err := os.Open(*path)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "open file: %v\n", err)
+	if *count < 1 {
+		fmt.Fprintln(os.Stderr, "count must be greater than zero")
 		os.Exit(1)
 	}
-	defer file.Close()
-
-	stat, err := file.Stat()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "stat file: %v\n", err)
-		os.Exit(1)
+	if *generate && *path != "" {
+		fmt.Fprintln(os.Stderr, "generate-transfer and file cannot be used together")
+		os.Exit(2)
+	}
+	if !*generate && *path == "" {
+		fmt.Fprintln(os.Stderr, "file is required unless generate-transfer is set")
+		os.Exit(2)
+	}
+	if *count == 1 && *key == "" && *keyPrefix == "" {
+		fmt.Fprintln(os.Stderr, "key or key-prefix is required")
+		os.Exit(2)
 	}
 
 	ctx := context.Background()
@@ -63,13 +74,96 @@ func main() {
 		opts.Region = *region
 	})
 
-	if _, err := client.PutObject(ctx, &s3.PutObjectInput{
-		Bucket:        bucket,
-		Key:           key,
-		Body:          file,
-		ContentLength: aws.Int64(stat.Size()),
-	}); err != nil {
-		fmt.Fprintf(os.Stderr, "put object: %v\n", err)
-		os.Exit(1)
+	for i := 1; i <= *count; i++ {
+		objectKey, err := nextKey(*key, *keyPrefix, *count, i)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		}
+
+		err = putTransfer(ctx, client, *bucket, objectKey, *path, *generate, i)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "put object %q: %v\n", objectKey, err)
+			os.Exit(1)
+		}
+		fmt.Printf("uploaded s3://%s/%s\n", *bucket, objectKey)
 	}
+}
+
+func putTransfer(ctx context.Context, client *s3.Client, bucket, key, path string, generate bool, index int) error {
+	if generate {
+		payload, err := generateTransfer(key, index)
+		if err != nil {
+			return fmt.Errorf("generate transfer: %w", err)
+		}
+		return putObject(ctx, client, bucket, key, bytes.NewReader(payload), int64(len(payload)))
+	}
+
+	return putFile(ctx, client, bucket, key, path)
+}
+
+func nextKey(key, prefix string, count, index int) (string, error) {
+	if count == 1 && key != "" {
+		return key, nil
+	}
+	if prefix == "" {
+		return "", fmt.Errorf("key-prefix is required when uploading multiple objects or when key is empty")
+	}
+
+	return fmt.Sprintf("%s-%03d.zip", strings.TrimSuffix(prefix, ".zip"), index), nil
+}
+
+func putFile(ctx context.Context, client *s3.Client, bucket, key, path string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open file: %w", err)
+	}
+	defer file.Close()
+
+	stat, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("stat file: %w", err)
+	}
+
+	return putObject(ctx, client, bucket, key, file, stat.Size())
+}
+
+func putObject(ctx context.Context, client *s3.Client, bucket, key string, body io.Reader, size int64) error {
+	_, err := client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:        aws.String(bucket),
+		Key:           aws.String(key),
+		Body:          body,
+		ContentLength: aws.Int64(size),
+	})
+	return err
+}
+
+func generateTransfer(key string, index int) ([]byte, error) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	files := map[string]string{
+		"objects/hello.txt": fmt.Sprintf("Generated transfer %03d for %s\n", index, key),
+		"metadata/source.txt": fmt.Sprintf(
+			"Created by hack/s3put at %s\nObject key: %s\n",
+			time.Now().UTC().Format(time.RFC3339),
+			key,
+		),
+	}
+
+	for name, content := range files {
+		w, err := zw.Create(name)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := io.WriteString(w, content); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := zw.Close(); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
 }

--- a/hack/s3put/main_test.go
+++ b/hack/s3put/main_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestNextKey(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		key     string
+		prefix  string
+		count   int
+		index   int
+		want    string
+		wantErr bool
+	}{
+		"single upload uses explicit key": {
+			key:    "transfer.zip",
+			prefix: "ignored",
+			count:  1,
+			index:  1,
+			want:   "transfer.zip",
+		},
+		"single upload can use generated key": {
+			prefix: "issue-681",
+			count:  1,
+			index:  1,
+			want:   "issue-681-001.zip",
+		},
+		"multiple uploads use generated keys": {
+			prefix: "issue-681.zip",
+			count:  25,
+			index:  7,
+			want:   "issue-681-007.zip",
+		},
+		"generated key requires prefix": {
+			count:   2,
+			index:   1,
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := nextKey(tc.key, tc.prefix, tc.count, tc.index)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("nextKey returned error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("nextKey = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGenerateTransfer(t *testing.T) {
+	t.Parallel()
+
+	const key = "issue-681-001.zip"
+	payload, err := generateTransfer(key, 1)
+	if err != nil {
+		t.Fatalf("generateTransfer returned error: %v", err)
+	}
+
+	zr, err := zip.NewReader(bytes.NewReader(payload), int64(len(payload)))
+	if err != nil {
+		t.Fatalf("generated payload is not a zip file: %v", err)
+	}
+
+	files := map[string]string{}
+	for _, file := range zr.File {
+		rc, err := file.Open()
+		if err != nil {
+			t.Fatalf("open generated file %q: %v", file.Name, err)
+		}
+		body, err := io.ReadAll(rc)
+		if closeErr := rc.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+		if err != nil {
+			t.Fatalf("read generated file %q: %v", file.Name, err)
+		}
+		files[file.Name] = string(body)
+	}
+
+	if !strings.Contains(files["objects/hello.txt"], key) {
+		t.Fatalf("objects/hello.txt does not mention object key: %q", files["objects/hello.txt"])
+	}
+	if !strings.Contains(files["metadata/source.txt"], key) {
+		t.Fatalf("metadata/source.txt does not mention object key: %q", files["metadata/source.txt"])
+	}
+}

--- a/internal/collection/collection_test.go
+++ b/internal/collection/collection_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"errors"
 	"fmt"
+	"io"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -58,9 +60,20 @@ func TestUpdateReconciliationState(t *testing.T) {
 }
 
 type execRecorderDB struct {
-	db    *sql.DB
+	db *sql.DB
+
 	query string
 	args  []any
+
+	execQuery string
+	execArgs  []any
+	querySQL  string
+	queryArgs []any
+
+	rowsAffected int64
+	execErr      error
+	queryErr     error
+	row          *Collection
 }
 
 var execRecorderDriverID atomic.Uint64
@@ -68,7 +81,7 @@ var execRecorderDriverID atomic.Uint64
 func newExecRecorderDB(t *testing.T) *execRecorderDB {
 	t.Helper()
 
-	recorder := &execRecorderDB{}
+	recorder := &execRecorderDB{rowsAffected: 1}
 	driverName := fmt.Sprintf("collection-test-driver-%d", execRecorderDriverID.Add(1))
 	sql.Register(driverName, execRecorderDriver{recorder: recorder})
 
@@ -105,10 +118,108 @@ func (c execRecorderConn) Begin() (driver.Tx, error)           { return nil, dri
 
 func (c execRecorderConn) ExecContext(_ context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
 	c.recorder.query = query
+	c.recorder.execQuery = query
 	c.recorder.args = make([]any, len(args))
+	c.recorder.execArgs = make([]any, len(args))
 	for i, arg := range args {
 		c.recorder.args[i] = arg.Value
+		c.recorder.execArgs[i] = arg.Value
 	}
 
-	return driver.RowsAffected(1), nil
+	if c.recorder.execErr != nil {
+		return nil, c.recorder.execErr
+	}
+
+	return driver.RowsAffected(c.recorder.rowsAffected), nil
 }
+
+func (c execRecorderConn) QueryContext(_ context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	c.recorder.querySQL = query
+	c.recorder.queryArgs = make([]any, len(args))
+	for i, arg := range args {
+		c.recorder.queryArgs[i] = arg.Value
+	}
+
+	if c.recorder.queryErr != nil {
+		return nil, c.recorder.queryErr
+	}
+
+	return &collectionRows{row: c.recorder.row}, nil
+}
+
+type collectionRows struct {
+	row  *Collection
+	done bool
+}
+
+func (r *collectionRows) Columns() []string {
+	return []string{
+		"id",
+		"name",
+		"workflow_id",
+		"run_id",
+		"transfer_id",
+		"aip_id",
+		"original_id",
+		"pipeline_id",
+		"decision_token",
+		"status",
+		"created_at",
+		"started_at",
+		"completed_at",
+		"aip_stored_at",
+		"reconciliation_status",
+		"reconciliation_checked_at",
+		"reconciliation_error",
+	}
+}
+
+func (r *collectionRows) Close() error {
+	return nil
+}
+
+func (r *collectionRows) Next(dest []driver.Value) error {
+	if r.done || r.row == nil {
+		return io.EOF
+	}
+	r.done = true
+
+	values := []driver.Value{
+		int64(r.row.ID),
+		r.row.Name,
+		r.row.WorkflowID,
+		r.row.RunID,
+		r.row.TransferID,
+		r.row.AIPID,
+		r.row.OriginalID,
+		r.row.PipelineID,
+		r.row.DecisionToken,
+		int64(r.row.Status),
+		r.row.CreatedAt,
+		nullTimeValue(r.row.StartedAt),
+		nullTimeValue(r.row.CompletedAt),
+		nullTimeValue(r.row.AIPStoredAt),
+		nullStringValue(r.row.ReconciliationStatus),
+		nullTimeValue(r.row.ReconciliationCheckedAt),
+		nullStringValue(r.row.ReconciliationError),
+	}
+	copy(dest, values)
+
+	return nil
+}
+
+func nullTimeValue(v sql.NullTime) driver.Value {
+	if !v.Valid {
+		return nil
+	}
+	return v.Time
+}
+
+func nullStringValue(v sql.NullString) driver.Value {
+	if !v.Valid {
+		return nil
+	}
+	return v.String
+}
+
+var errTestDB = errors.New("database error")

--- a/internal/collection/goa_test.go
+++ b/internal/collection/goa_test.go
@@ -3,10 +3,13 @@ package collection
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/mock"
+	temporalsdk_mocks "go.temporal.io/sdk/mocks"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/poll"
 
@@ -50,6 +53,152 @@ func TestGoaMonitor(t *testing.T) {
 		cancel()
 		assert.NilError(t, <-done)
 	})
+}
+
+func TestGoaDelete(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		rowsAffected int64
+		execErr      error
+		wantErr      error
+		wantNotFound bool
+		wantEvent    bool
+	}{
+		"deletes existing collection": {
+			rowsAffected: 1,
+			wantEvent:    true,
+		},
+		"returns not found when no row is deleted": {
+			rowsAffected: 0,
+			wantNotFound: true,
+		},
+		"returns database error": {
+			rowsAffected: 1,
+			execErr:      errTestDB,
+			wantErr:      errTestDB,
+		},
+		"does not cancel workflow": {
+			rowsAffected: 1,
+			wantEvent:    true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			recorder := newExecRecorderDB(t)
+			recorder.rowsAffected = tc.rowsAffected
+			recorder.execErr = tc.execErr
+
+			client := &temporalsdk_mocks.Client{}
+			events := NewEventService()
+			sub, err := events.Subscribe(ctx)
+			assert.NilError(t, err)
+			defer sub.Close()
+
+			svc := NewService(testLogger(), recorder.db, client, "", nil)
+			svc.events = events
+
+			err = svc.Goa().Delete(ctx, &goacollection.DeletePayload{ID: 42})
+
+			assert.Equal(t, recorder.execQuery, "DELETE FROM collection WHERE id = (?)")
+			assert.DeepEqual(t, recorder.execArgs, []any{int64(42)})
+
+			assertGoaServiceErr(t, err, tc.wantErr, tc.wantNotFound)
+			assertCollectionEvent(t, sub, tc.wantEvent, EventTypeCollectionDeleted, 42)
+			client.AssertExpectations(t)
+		})
+	}
+}
+
+func TestGoaCancel(t *testing.T) {
+	t.Parallel()
+
+	errTemporal := errors.New("temporal error")
+	createdAt := time.Date(2026, time.June, 11, 10, 0, 0, 0, time.UTC)
+	row := &Collection{
+		ID:         42,
+		Name:       "collection",
+		WorkflowID: "processing-workflow-04e9257e-ac59-442c-a037-7504ea5ebf3f",
+		RunID:      "74795d4e-4530-4dc1-bb7b-7457ef3c9d75",
+		Status:     StatusQueued,
+		CreatedAt:  createdAt,
+	}
+
+	tests := map[string]struct {
+		row          *Collection
+		queryErr     error
+		cancelErr    error
+		wantErr      error
+		wantNotFound bool
+		wantEvent    bool
+		wantCancel   bool
+	}{
+		"cancels workflow for existing collection": {
+			row:        row,
+			wantEvent:  true,
+			wantCancel: true,
+		},
+		"returns not found when collection is missing": {
+			wantNotFound: true,
+		},
+		"returns database read error": {
+			queryErr: errTestDB,
+			wantErr:  errTestDB,
+		},
+		"returns temporal cancellation error": {
+			row:        row,
+			cancelErr:  errTemporal,
+			wantErr:    errTemporal,
+			wantCancel: true,
+		},
+		"does not delete collection row": {
+			row:        row,
+			wantEvent:  true,
+			wantCancel: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			recorder := newExecRecorderDB(t)
+			recorder.row = tc.row
+			recorder.queryErr = tc.queryErr
+
+			client := &temporalsdk_mocks.Client{}
+			if tc.wantCancel {
+				client.On(
+					"CancelWorkflow",
+					mock.Anything,
+					row.WorkflowID,
+					row.RunID,
+				).Return(tc.cancelErr).Once()
+			}
+
+			events := NewEventService()
+			sub, err := events.Subscribe(ctx)
+			assert.NilError(t, err)
+			defer sub.Close()
+
+			svc := NewService(testLogger(), recorder.db, client, "", nil)
+			svc.events = events
+
+			err = svc.Goa().Cancel(ctx, &goacollection.CancelPayload{ID: 42})
+
+			assert.Equal(t, recorder.execQuery, "")
+			assert.DeepEqual(t, recorder.queryArgs, []any{int64(42)})
+
+			assertGoaServiceErr(t, err, tc.wantErr, tc.wantNotFound)
+			assertCollectionEvent(t, sub, tc.wantEvent, EventTypeCollectionUpdated, 42)
+			client.AssertExpectations(t)
+		})
+	}
 }
 
 func TestRetryModeForCollection(t *testing.T) {
@@ -191,6 +340,37 @@ func TestNewRetryResult(t *testing.T) {
 	got := newRetryResult(RetryModeReconcileExistingAIP)
 
 	assert.Equal(t, got.Mode, string(RetryModeReconcileExistingAIP))
+}
+
+func assertGoaServiceErr(t *testing.T, err, wantErr error, wantNotFound bool) {
+	t.Helper()
+
+	if wantNotFound {
+		var notFound *goacollection.CollectionNotfound
+		assert.Assert(t, errors.As(err, &notFound))
+		assert.Equal(t, notFound.ID, uint(42))
+		return
+	}
+
+	if wantErr != nil {
+		assert.ErrorIs(t, err, wantErr)
+		return
+	}
+
+	assert.NilError(t, err)
+}
+
+func assertCollectionEvent(t *testing.T, sub Subscription, want bool, eventType string, id uint) {
+	t.Helper()
+
+	select {
+	case got := <-sub.C():
+		assert.Assert(t, want, "unexpected collection event")
+		assert.Equal(t, got.Type, eventType)
+		assert.Equal(t, got.ID, id)
+	default:
+		assert.Assert(t, !want, "expected collection event")
+	}
 }
 
 func waitForSubscriptions(t *testing.T, events *EventServiceImpl, count int) {

--- a/internal/workflow/processing.go
+++ b/internal/workflow/processing.go
@@ -267,10 +267,7 @@ func (w *ProcessingWorkflow) Execute(ctx temporalsdk_workflow.Context, req *coll
 	// Ensure that the status of the collection is always updated when this
 	// workflow function returns.
 	defer func() {
-		// Mark as failed unless it completed successfully or it was abandoned.
-		if status != collection.StatusDone && status != collection.StatusAbandoned {
-			status = collection.StatusError
-		}
+		status = finalCollectionStatus(status, ctx.Err() == temporalsdk_workflow.ErrCanceled)
 
 		// Use disconnected context so it also runs after cancellation.
 		dctx, _ := temporalsdk_workflow.NewDisconnectedContext(ctx)
@@ -455,6 +452,16 @@ func (w *ProcessingWorkflow) Execute(ctx temporalsdk_workflow.Context, req *coll
 	)
 
 	return nil
+}
+
+func finalCollectionStatus(status collection.Status, canceled bool) collection.Status {
+	if status == collection.StatusDone || status == collection.StatusAbandoned {
+		return status
+	}
+	if canceled {
+		return collection.StatusAbandoned
+	}
+	return collection.StatusError
 }
 
 // SessionHandler runs activities that belong to the same session.

--- a/internal/workflow/processing_test.go
+++ b/internal/workflow/processing_test.go
@@ -130,6 +130,47 @@ func (s *ProcessingWorkflowTestSuite) TestParseError() {
 	s.ErrorContains(s.env.GetWorkflowError(), "parse error")
 }
 
+func TestFinalCollectionStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		status   collection.Status
+		canceled bool
+		want     collection.Status
+	}{
+		"done remains done": {
+			status: collection.StatusDone,
+			want:   collection.StatusDone,
+		},
+		"abandoned remains abandoned": {
+			status: collection.StatusAbandoned,
+			want:   collection.StatusAbandoned,
+		},
+		"non-terminal success path defaults to error": {
+			status: collection.StatusQueued,
+			want:   collection.StatusError,
+		},
+		"canceled queued workflow becomes abandoned": {
+			status:   collection.StatusQueued,
+			canceled: true,
+			want:     collection.StatusAbandoned,
+		},
+		"canceled in-progress workflow becomes abandoned": {
+			status:   collection.StatusInProgress,
+			canceled: true,
+			want:     collection.StatusAbandoned,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := finalCollectionStatus(tc.status, tc.canceled)
+			assert.Equal(t, got, tc.want)
+		})
+	}
+}
+
 func (s *ProcessingWorkflowTestSuite) TestReconciliationRetryPreservesExistingState() {
 	ctrl := gomock.NewController(s.T())
 	pipelineRegistry, err := pipeline.NewPipelineRegistry(logr.Discard(), []pipeline.Config{

--- a/ui/src/views/CollectionShow.vue
+++ b/ui/src/views/CollectionShow.vue
@@ -109,7 +109,7 @@
           <b-button-group size="sm">
             <b-button :to="{ name: 'collection-workflow', items: {id: collection.id} }">Status</b-button>
             <b-button v-if="collection.status == 'error'" variant="info" v-on:click="retry(collection.id)">Retry</b-button>
-            <b-button v-if="collection.status == 'in progress'" variant="dark" v-on:click="cancel(collection.id)">Cancel</b-button>
+            <b-button v-if="canCancel" variant="dark" v-on:click="cancel(collection.id)">Cancel</b-button>
           </b-button-group>
         </b-card-text>
       </b-card>
@@ -191,6 +191,13 @@ export default class CollectionShow extends Vue {
       return false;
     }
     return ['pending'].includes(this.collection.status);
+  }
+
+  private get canCancel() {
+    if (!this.collection) {
+      return false;
+    }
+    return this.collection.status == 'in progress' || (this.collection.status == 'queued' && !this.collection.transferId);
   }
 
   private onDelete() {


### PR DESCRIPTION
Expose Cancel for queued collections that have not yet received an Archivematica transfer ID. This lets operators stop Enduro-owned work before it is submitted downstream, while keeping submitted Archivematica work out of scope.

The relevant transition changes are:

- Queued => Abandoned: pressing Cancel is now allowed before an Archivematica transfer ID exists, preventing downstream submission.
- In progress => Abandoned: pressing Cancel still stops Enduro's Temporal workflow, but submitted Archivematica work may continue outside tracking.
- Canceled non-terminal workflow => Abandoned: the workflow defer now records cancellation as Abandoned instead of falling through to Error.

All known status transitions and dashboard operations are know documented.