### PR TITLE
Support standalone recovery locations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
     - importas
     - intrange
     - misspell
+    - modernize
   settings:
     importas:
       alias:

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -725,6 +725,9 @@ At a high level:
 - set `requiredLocations` to one or more Storage Service location UUIDs when
   those locations must also be confirmed before the collection is considered
   complete
+- set `standaloneLocations` to primary Storage Service location UUIDs that are
+  final storage destinations even when `requiredLocations` is configured for
+  packages stored elsewhere
 
 #### `capacity` (Integer)
 

--- a/docs/user-manual-recovery.md
+++ b/docs/user-manual-recovery.md
@@ -145,6 +145,20 @@ Use the minimal form when the primary package alone is enough to satisfy your
 storage rule. Omitting `requiredLocations` has the same effect as setting it to
 `[]`. Add `requiredLocations` only when specific Storage Service locations must
 also be confirmed before Enduro should treat the collection as fully stored.
+If the same pipeline can send packages to both replicated and non-replicated
+AIP stores, add the non-replicated primary package locations to
+`standaloneLocations`:
+
+```toml
+[pipeline.recovery]
+reconcileExistingAIP = true
+requiredLocations = ["cloud-location-id", "cloud-replica-location-id"]
+standaloneLocations = ["local-location-id", "vpaa-location-id"]
+```
+
+When the primary package is in a standalone location, Enduro treats the primary
+stored date as the completion condition and does not require replicas. Packages
+stored outside standalone locations still need every `requiredLocations` entry.
 
 Example based on a fuller pipeline definition:
 
@@ -176,6 +190,14 @@ reconcileExistingAIP = true
 requiredLocations = [
   "primary-location-id",
   "replica-location-id",
+]
+
+# Optional. Primary package locations where the primary package is the final
+# storage destination, even when requiredLocations is configured for packages
+# stored elsewhere.
+standaloneLocations = [
+  "local-location-id",
+  "vpaa-location-id",
 ]
 ```
 
@@ -257,18 +279,34 @@ Guidance:
 - only include locations that operators are prepared to monitor; every required
   location becomes part of the success condition
 
+### `standaloneLocations` (Array(String))
+
+Primary Storage Service locations where the package is considered fully stored
+from its primary stored date. Use this when one pipeline handles both replicated
+and non-replicated AIP stores. When the primary package is in one of these
+locations, Enduro does not require `requiredLocations` for that package.
+
+E.g.: `["local-location-id", "vpaa-location-id"]`
+
+Guidance:
+
+- include only primary package locations that are final storage destinations
+- do not use this as a list of replica locations that may fail
+- omit this setting when every package in the pipeline should follow the same
+  `requiredLocations` rule
+
 ## Finding valid Storage Service location IDs
 
-`requiredLocations` must use Storage Service location UUIDs. Enduro does not
-invent these values.
+`requiredLocations` and `standaloneLocations` must use Storage Service location
+UUIDs. Enduro does not invent these values.
 
 Operators should obtain them from Archivematica Storage Service and record the
 UUIDs they intend to use in pipeline configuration. In practice, this means
-looking up the primary package location and any replica locations in Storage
-Service before enabling recovery.
+looking up the primary package location, any standalone package locations, and
+any replica locations in Storage Service before enabling recovery.
 
 If multiple pipelines have different storage policies, each pipeline can use a
-different `requiredLocations` list.
+different `requiredLocations` and `standaloneLocations` list.
 
 ## Reconciliation after ingest
 

--- a/go.mod
+++ b/go.mod
@@ -148,7 +148,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go4.org v0.0.0-20230225012048-214862532bf5 // indirect
-	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8 // indirect
 	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -529,8 +529,6 @@ golang.org/x/exp v0.0.0-20191030013958-a1ab85dbe136/go.mod h1:JXzH8nQsPlswgeRAPE
 golang.org/x/exp v0.0.0-20191129062945-2f5052295587/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
-golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8 h1:aAcj0Da7eBAtrTp03QXWvm88pSyOt+UgdZw2BFZ+lEw=
-golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8/go.mod h1:CQ1k9gNrJ50XIzaKCRR2hssIjF07kZFEiieALBM/ARQ=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -40,7 +40,6 @@ func TestSecurityHeadersMiddleware(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -138,7 +137,6 @@ func TestCrossOriginProtectionMiddleware(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -212,7 +210,6 @@ func TestCORSResponseHeaderMiddleware(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/batch/service.go
+++ b/internal/batch/service.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"go.artefactual.dev/tools/ref"
 	"go.opentelemetry.io/otel/trace/noop"
 	temporalapi_enums "go.temporal.io/api/enums/v1"
 	temporalapi_serviceerror "go.temporal.io/api/serviceerror"
@@ -136,7 +135,7 @@ func (s *batchImpl) Status(ctx context.Context) (*goabatch.BatchStatusResult, er
 		result.Running = true
 		return result, nil
 	}
-	result.Status = ref.New(strings.ToLower(resp.WorkflowExecutionInfo.Status.String()))
+	result.Status = new(strings.ToLower(resp.WorkflowExecutionInfo.Status.String()))
 	return result, nil
 }
 

--- a/internal/collection/goa_test.go
+++ b/internal/collection/goa_test.go
@@ -304,6 +304,66 @@ func TestCollectionGoaDetailIncludesReconciliationFields(t *testing.T) {
 	assert.Equal(t, *got.ReconciliationError, "replica lag")
 }
 
+func TestCollectionGoaSummary(t *testing.T) {
+	t.Parallel()
+
+	location := time.FixedZone("CEST", 2*60*60)
+	storedAt := time.Date(2026, time.June, 17, 12, 30, 0, 0, location)
+	col := Collection{
+		ID:         42,
+		Name:       "collection",
+		WorkflowID: "processing-workflow-04e9257e-ac59-442c-a037-7504ea5ebf3f",
+		RunID:      "74795d4e-4530-4dc1-bb7b-7457ef3c9d75",
+		TransferID: "a5581c4f-c3f7-45c2-b756-787ab9669479",
+		AIPID:      "0f83f8f8-79df-4851-a89d-a4e61e9ef112",
+		OriginalID: "original-identifier",
+		PipelineID: "d964fcd2-7f3f-4640-9068-edcaacf0411b",
+		Status:     StatusDone,
+		CreatedAt:  storedAt.Add(-time.Hour),
+		StartedAt: sql.NullTime{
+			Time:  storedAt.Add(-30 * time.Minute),
+			Valid: true,
+		},
+		CompletedAt: sql.NullTime{
+			Time:  storedAt,
+			Valid: true,
+		},
+		AIPStoredAt: sql.NullTime{
+			Time:  time.Now().UTC(),
+			Valid: true,
+		},
+		ReconciliationStatus: sql.NullString{
+			String: "partial",
+			Valid:  true,
+		},
+		ReconciliationCheckedAt: sql.NullTime{
+			Time:  time.Now().UTC(),
+			Valid: true,
+		},
+		ReconciliationError: sql.NullString{
+			String: "replica missing",
+			Valid:  true,
+		},
+	}
+
+	got := col.GoaSummary()
+
+	assert.DeepEqual(t, got, &goacollection.EnduroStoredCollection{
+		ID:          42,
+		Name:        new("collection"),
+		WorkflowID:  new("processing-workflow-04e9257e-ac59-442c-a037-7504ea5ebf3f"),
+		RunID:       new("74795d4e-4530-4dc1-bb7b-7457ef3c9d75"),
+		TransferID:  new("a5581c4f-c3f7-45c2-b756-787ab9669479"),
+		AipID:       new("0f83f8f8-79df-4851-a89d-a4e61e9ef112"),
+		OriginalID:  new("original-identifier"),
+		PipelineID:  new("d964fcd2-7f3f-4640-9068-edcaacf0411b"),
+		Status:      "done",
+		CreatedAt:   "2026-06-17T09:30:00Z",
+		StartedAt:   new("2026-06-17T10:00:00Z"),
+		CompletedAt: new("2026-06-17T10:30:00Z"),
+	})
+}
+
 func TestCollectionGoaSummaryOmitsReconciliationFields(t *testing.T) {
 	t.Parallel()
 

--- a/internal/collection/types.go
+++ b/internal/collection/types.go
@@ -116,7 +116,7 @@ func formatOptionalNullString(ns sql.NullString) *string {
 func formatTime(t time.Time) string {
 	var ret string
 	if !t.IsZero() {
-		ret = t.Format(time.RFC3339)
+		ret = t.UTC().Format(time.RFC3339)
 	}
 	return ret
 }

--- a/internal/nha/activities/hari_test.go
+++ b/internal/nha/activities/hari_test.go
@@ -418,7 +418,6 @@ func TestHARIActivity(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/nha/activities/prod_test.go
+++ b/internal/nha/activities/prod_test.go
@@ -113,7 +113,6 @@ func TestProdActivity(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -47,6 +48,15 @@ type Config struct {
 type RecoveryConfig struct {
 	ReconcileExistingAIP bool
 	RequiredLocations    []string
+	StandaloneLocations  []string
+}
+
+func (c RecoveryConfig) IsStandaloneLocation(locationID string) bool {
+	if locationID == "" {
+		return false
+	}
+
+	return slices.Contains(c.StandaloneLocations, locationID)
 }
 
 func (c Config) Validate() error {

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -1,9 +1,11 @@
 package pipeline
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/spf13/viper"
 	"gotest.tools/v3/assert"
 
 	"github.com/artefactual-labs/enduro/internal/publisher"
@@ -174,6 +176,38 @@ func TestPipelineConfigValidate(t *testing.T) {
 			assert.ErrorContains(t, err, tc.errContains)
 		})
 	}
+}
+
+func TestPipelineConfigUnmarshalsStandaloneLocations(t *testing.T) {
+	t.Parallel()
+
+	v := viper.New()
+	v.SetConfigType("toml")
+	err := v.ReadConfig(strings.NewReader(`
+[[pipeline]]
+name = "am"
+
+[pipeline.recovery]
+reconcileExistingAIP = true
+requiredLocations = ["required-location"]
+standaloneLocations = ["local-location", "vpaa-location"]
+`))
+	assert.NilError(t, err)
+
+	type config struct {
+		Pipeline []Config
+	}
+
+	var c config
+	err = v.Unmarshal(&c)
+	assert.NilError(t, err)
+
+	assert.Equal(t, len(c.Pipeline), 1)
+	assert.DeepEqual(t, c.Pipeline[0].Recovery, RecoveryConfig{
+		ReconcileExistingAIP: true,
+		RequiredLocations:    []string{"required-location"},
+		StandaloneLocations:  []string{"local-location", "vpaa-location"},
+	})
 }
 
 func testCapacity(t *testing.T, p *Pipeline, s, c int64) {

--- a/internal/pipeline/status_test.go
+++ b/internal/pipeline/status_test.go
@@ -212,7 +212,7 @@ func TestTransferStatus(t *testing.T) {
 						nil,
 					)
 			},
-			wantSID: strPtr("fb901f48-8d38-4e1b-8047-6e03a0079439"),
+			wantSID: new("fb901f48-8d38-4e1b-8047-6e03a0079439"),
 			wantErr: nil,
 		},
 	}
@@ -432,10 +432,6 @@ func TestIngestStatus(t *testing.T) {
 			assert.Equal(t, errors.Is(err, tc.wantErr), true)
 		})
 	}
-}
-
-func strPtr(str string) *string {
-	return &str
 }
 
 type fakeTimeoutError struct{}

--- a/internal/pipeline/storage.go
+++ b/internal/pipeline/storage.go
@@ -38,17 +38,23 @@ type StorageReplica struct {
 }
 
 func (p *Pipeline) GetStoragePackage(ctx context.Context, aipID string) (*StoragePackage, error) {
-	return p.getStoragePackage(ctx, aipID, true)
+	return p.getStoragePackage(ctx, aipID, alwaysLoadStorageReplicas)
 }
 
 // GetStoragePackageForReconciliation returns only the storage details needed
 // by the configured recovery policy. Primary-only policies do not need replica
 // hydration, so unrelated replica problems should not block reconciliation.
 func (p *Pipeline) GetStoragePackageForReconciliation(ctx context.Context, aipID string, cfg RecoveryConfig) (*StoragePackage, error) {
-	return p.getStoragePackage(ctx, aipID, len(cfg.RequiredLocations) > 0)
+	return p.getStoragePackage(ctx, aipID, func(pkg *StoragePackage) bool {
+		return len(cfg.RequiredLocations) > 0 && !cfg.IsStandaloneLocation(pkg.CurrentLocation.UUID)
+	})
 }
 
-func (p *Pipeline) getStoragePackage(ctx context.Context, aipID string, loadReplicas bool) (*StoragePackage, error) {
+func alwaysLoadStorageReplicas(*StoragePackage) bool {
+	return true
+}
+
+func (p *Pipeline) getStoragePackage(ctx context.Context, aipID string, shouldLoadReplicas func(*StoragePackage) bool) (*StoragePackage, error) {
 	if p.storageServiceClient == nil {
 		return nil, errors.New("storage service client is not configured")
 	}
@@ -69,7 +75,7 @@ func (p *Pipeline) getStoragePackage(ctx context.Context, aipID string, loadRepl
 		return nil, errors.New("storage service returned an empty package response")
 	}
 
-	return p.normalizeStoragePackage(ctx, pkg, loadReplicas)
+	return p.normalizeStoragePackage(ctx, pkg, shouldLoadReplicas)
 }
 
 func (p *Pipeline) DownloadStoragePackage(ctx context.Context, aipID string) (*ssclient.FileStream, error) {
@@ -96,7 +102,7 @@ func (p *Pipeline) DownloadStoragePackage(ctx context.Context, aipID string) (*s
 	return stream, nil
 }
 
-func (p *Pipeline) normalizeStoragePackage(ctx context.Context, pkg *models.PackageEscaped, loadReplicas bool) (*StoragePackage, error) {
+func (p *Pipeline) normalizeStoragePackage(ctx context.Context, pkg *models.PackageEscaped, shouldLoadReplicas func(*StoragePackage) bool) (*StoragePackage, error) {
 	out := &StoragePackage{
 		UUID:            derefUUID(pkg.GetUuid()),
 		Status:          derefString(pkg.GetStatus()),
@@ -112,7 +118,7 @@ func (p *Pipeline) normalizeStoragePackage(ctx context.Context, pkg *models.Pack
 		out.CurrentLocation = StorageLocation{UUID: locationID}
 	}
 
-	if !loadReplicas {
+	if shouldLoadReplicas == nil || !shouldLoadReplicas(out) {
 		return out, nil
 	}
 

--- a/internal/pipeline/storage_test.go
+++ b/internal/pipeline/storage_test.go
@@ -41,20 +41,20 @@ func TestGetStoragePackage(t *testing.T) {
 					primaryStoredAt := time.Date(2026, 3, 17, 7, 0, 0, 0, time.UTC)
 					pkg := models.NewPackageEscaped()
 					pkg.SetUuid(uuidPtr("11111111-1111-1111-1111-111111111111"))
-					pkg.SetStatus(stringPtr("UPLOADED"))
+					pkg.SetStatus(new("UPLOADED"))
 					pkg.SetStoredDate(&primaryStoredAt)
-					pkg.SetCurrentFullPath(stringPtr("/var/aips/" + primaryID + ".7z"))
-					pkg.SetCurrentLocation(stringPtr("/api/v2/location/" + primaryLoc + "/"))
+					pkg.SetCurrentFullPath(new("/var/aips/" + primaryID + ".7z"))
+					pkg.SetCurrentLocation(new("/api/v2/location/" + primaryLoc + "/"))
 					pkg.SetReplicas([]string{"/api/v2/file/" + replicaID + "/"})
 					return pkg, nil
 				case replicaID:
 					replicaStoredAt := time.Date(2026, 3, 17, 8, 0, 0, 0, time.UTC)
 					pkg := models.NewPackageEscaped()
 					pkg.SetUuid(uuidPtr("22222222-2222-2222-2222-222222222222"))
-					pkg.SetStatus(stringPtr("UPLOADED"))
+					pkg.SetStatus(new("UPLOADED"))
 					pkg.SetStoredDate(&replicaStoredAt)
-					pkg.SetCurrentFullPath(stringPtr("/replicas/" + primaryID + ".7z"))
-					pkg.SetCurrentLocation(stringPtr("/api/v2/location/" + replicaLoc + "/"))
+					pkg.SetCurrentFullPath(new("/replicas/" + primaryID + ".7z"))
+					pkg.SetCurrentLocation(new("/api/v2/location/" + replicaLoc + "/"))
 					pkg.SetReplicas([]string{})
 					return pkg, nil
 				default:
@@ -154,7 +154,7 @@ func TestGetStoragePackage(t *testing.T) {
 			send: func(ctx context.Context, requestInfo *kabs.RequestInformation, constructor serialization.ParsableFactory, errorMappings kabs.ErrorMappings) (serialization.Parsable, error) {
 				pkg := models.NewPackageEscaped()
 				pkg.SetUuid(uuidPtr("11111111-1111-1111-1111-111111111111"))
-				pkg.SetCurrentLocation(stringPtr("not-a-uri"))
+				pkg.SetCurrentLocation(new("not-a-uri"))
 				return pkg, nil
 			},
 		})
@@ -255,7 +255,7 @@ func TestGetStoragePackage(t *testing.T) {
 					pkg.SetUuid(uuidPtr("11111111-1111-1111-1111-111111111111"))
 					storedAt := time.Date(2026, 3, 17, 7, 0, 0, 0, time.UTC)
 					pkg.SetStoredDate(&storedAt)
-					pkg.SetCurrentLocation(stringPtr("/api/v2/location/" + primaryLoc + "/"))
+					pkg.SetCurrentLocation(new("/api/v2/location/" + primaryLoc + "/"))
 					pkg.SetReplicas([]string{"/api/v2/file/" + replicaID + "/"})
 					return pkg, nil
 				case replicaID:
@@ -296,7 +296,7 @@ func TestGetStoragePackage(t *testing.T) {
 					pkg.SetUuid(uuidPtr("11111111-1111-1111-1111-111111111111"))
 					storedAt := time.Date(2026, 3, 17, 7, 0, 0, 0, time.UTC)
 					pkg.SetStoredDate(&storedAt)
-					pkg.SetCurrentLocation(stringPtr("/api/v2/location/" + primaryLoc + "/"))
+					pkg.SetCurrentLocation(new("/api/v2/location/" + primaryLoc + "/"))
 					pkg.SetReplicas([]string{"/api/v2/file/" + replicaID + "/"})
 					return pkg, nil
 				case replicaID:
@@ -304,7 +304,7 @@ func TestGetStoragePackage(t *testing.T) {
 					pkg := models.NewPackageEscaped()
 					pkg.SetUuid(uuidPtr("22222222-2222-2222-2222-222222222222"))
 					pkg.SetStoredDate(&replicaStoredAt)
-					pkg.SetCurrentLocation(stringPtr("/api/v2/location/" + replicaLoc + "/"))
+					pkg.SetCurrentLocation(new("/api/v2/location/" + replicaLoc + "/"))
 					return pkg, nil
 				default:
 					assert.Assert(t, false, "unexpected request UUID "+id)
@@ -532,10 +532,6 @@ func (f *fakeRequestAdapter) ConvertToNativeRequest(ctx context.Context, request
 func uuidPtr(value string) *uuid.UUID {
 	id := uuid.MustParse(value)
 	return &id
-}
-
-func stringPtr(value string) *string {
-	return &value
 }
 
 func pathUUIDString(t *testing.T, requestInfo *kabs.RequestInformation) string {

--- a/internal/pipeline/storage_test.go
+++ b/internal/pipeline/storage_test.go
@@ -238,6 +238,92 @@ func TestGetStoragePackage(t *testing.T) {
 		assert.Equal(t, len(pkg.Replicas), 0)
 	})
 
+	t.Run("Standalone reconciliation ignores replica lookup failures", func(t *testing.T) {
+		t.Parallel()
+
+		const (
+			primaryID  = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+			primaryLoc = "33333333-3333-4333-8333-333333333333"
+			replicaID  = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+		)
+
+		p := newStoragePipelineForTest(t, &fakeRequestAdapter{
+			send: func(ctx context.Context, requestInfo *kabs.RequestInformation, constructor serialization.ParsableFactory, errorMappings kabs.ErrorMappings) (serialization.Parsable, error) {
+				switch id := pathUUIDString(t, requestInfo); id {
+				case primaryID:
+					pkg := models.NewPackageEscaped()
+					pkg.SetUuid(uuidPtr("11111111-1111-1111-1111-111111111111"))
+					storedAt := time.Date(2026, 3, 17, 7, 0, 0, 0, time.UTC)
+					pkg.SetStoredDate(&storedAt)
+					pkg.SetCurrentLocation(stringPtr("/api/v2/location/" + primaryLoc + "/"))
+					pkg.SetReplicas([]string{"/api/v2/file/" + replicaID + "/"})
+					return pkg, nil
+				case replicaID:
+					return nil, errors.New("temporary replica lookup failure")
+				default:
+					assert.Assert(t, false, "unexpected request UUID "+id)
+					return nil, nil
+				}
+			},
+		})
+
+		pkg, err := p.GetStoragePackageForReconciliation(context.Background(), primaryID, RecoveryConfig{
+			RequiredLocations:   []string{"replica-location"},
+			StandaloneLocations: []string{primaryLoc},
+		})
+
+		assert.NilError(t, err)
+		assert.Assert(t, pkg != nil)
+		assert.Equal(t, pkg.CurrentLocation.UUID, primaryLoc)
+		assert.Equal(t, len(pkg.Replicas), 0)
+	})
+
+	t.Run("Replicated reconciliation hydrates replicas outside standalone locations", func(t *testing.T) {
+		t.Parallel()
+
+		const (
+			primaryID  = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+			primaryLoc = "33333333-3333-4333-8333-333333333333"
+			replicaID  = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+			replicaLoc = "44444444-4444-4444-8444-444444444444"
+		)
+
+		p := newStoragePipelineForTest(t, &fakeRequestAdapter{
+			send: func(ctx context.Context, requestInfo *kabs.RequestInformation, constructor serialization.ParsableFactory, errorMappings kabs.ErrorMappings) (serialization.Parsable, error) {
+				switch id := pathUUIDString(t, requestInfo); id {
+				case primaryID:
+					pkg := models.NewPackageEscaped()
+					pkg.SetUuid(uuidPtr("11111111-1111-1111-1111-111111111111"))
+					storedAt := time.Date(2026, 3, 17, 7, 0, 0, 0, time.UTC)
+					pkg.SetStoredDate(&storedAt)
+					pkg.SetCurrentLocation(stringPtr("/api/v2/location/" + primaryLoc + "/"))
+					pkg.SetReplicas([]string{"/api/v2/file/" + replicaID + "/"})
+					return pkg, nil
+				case replicaID:
+					replicaStoredAt := time.Date(2026, 3, 17, 8, 0, 0, 0, time.UTC)
+					pkg := models.NewPackageEscaped()
+					pkg.SetUuid(uuidPtr("22222222-2222-2222-2222-222222222222"))
+					pkg.SetStoredDate(&replicaStoredAt)
+					pkg.SetCurrentLocation(stringPtr("/api/v2/location/" + replicaLoc + "/"))
+					return pkg, nil
+				default:
+					assert.Assert(t, false, "unexpected request UUID "+id)
+					return nil, nil
+				}
+			},
+		})
+
+		pkg, err := p.GetStoragePackageForReconciliation(context.Background(), primaryID, RecoveryConfig{
+			RequiredLocations:   []string{replicaLoc},
+			StandaloneLocations: []string{"55555555-5555-4555-8555-555555555555"},
+		})
+
+		assert.NilError(t, err)
+		assert.Assert(t, pkg != nil)
+		assert.Equal(t, len(pkg.Replicas), 1)
+		assert.Equal(t, pkg.Replicas[0].CurrentLocation.UUID, replicaLoc)
+	})
+
 	t.Run("Rejects invalid package UUID", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/pipeline/sync/semaphore/semaphore_test.go
+++ b/internal/pipeline/sync/semaphore/semaphore_test.go
@@ -38,7 +38,6 @@ func TestWeighted(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(n)
 	for i := range n {
-		i := i
 		go func() {
 			defer wg.Done()
 			HammerWeighted(sem, int64(i), loops)

--- a/internal/reconciliation/reconciliation.go
+++ b/internal/reconciliation/reconciliation.go
@@ -15,8 +15,8 @@ const (
 	// ClassificationNotFound means Storage Service has no package for the AIP
 	// UUID, so a full reprocess may still be appropriate.
 	ClassificationNotFound Classification = "not_found"
-	// ClassificationLocalComplete means the primary AIP exists and no required
-	// replica locations are configured for the pipeline.
+	// ClassificationLocalComplete means the primary AIP exists and satisfies the
+	// configured recovery policy without requiring replica completion.
 	ClassificationLocalComplete Classification = "local_complete"
 	// ClassificationReplicatedPartial means the primary AIP exists but at least
 	// one configured required replica is still missing or lacks a stored date.
@@ -71,9 +71,10 @@ type Result struct {
 
 // ClassifyStorage translates Storage Service observations into Enduro's
 // recovery model. The policy decision is intentionally small:
-// when no required locations are configured, the primary AIP is the completion
-// target; otherwise every configured location must have a replica with a
-// concrete stored date before storage is considered complete.
+// when no required locations are configured, or the primary AIP is in a
+// standalone location, the primary AIP is the completion target; otherwise every
+// configured location must have a replica with a concrete stored date before
+// storage is considered complete.
 func ClassifyStorage(cfg pipeline.RecoveryConfig, pkg *pipeline.StoragePackage) Result {
 	if pkg == nil {
 		return Result{
@@ -95,7 +96,7 @@ func ClassifyStorage(cfg pipeline.RecoveryConfig, pkg *pipeline.StoragePackage) 
 		AIPStoredAt:   pkg.StoredDate,
 	}
 
-	if len(cfg.RequiredLocations) == 0 {
+	if len(cfg.RequiredLocations) == 0 || cfg.IsStandaloneLocation(pkg.CurrentLocation.UUID) {
 		result.Classification = ClassificationLocalComplete
 		result.Status = StatusComplete
 		result.StorageComplete = true

--- a/internal/reconciliation/reconciliation_test.go
+++ b/internal/reconciliation/reconciliation_test.go
@@ -73,6 +73,44 @@ func TestClassifyStorage(t *testing.T) {
 				AIPStoredAt:    &primaryStoredAt,
 			},
 		},
+		"Standalone storage completes from primary stored date when required locations are configured": {
+			cfg: pipeline.RecoveryConfig{
+				RequiredLocations:   []string{"replica-loc"},
+				StandaloneLocations: []string{"standalone-loc"},
+			},
+			pkg: &pipeline.StoragePackage{
+				StoredDate: &primaryStoredAt,
+				CurrentLocation: pipeline.StorageLocation{
+					UUID: "standalone-loc",
+				},
+			},
+			want: Result{
+				Classification:  ClassificationLocalComplete,
+				Status:          StatusComplete,
+				PrimaryExists:   true,
+				StorageComplete: true,
+				AIPStoredAt:     &primaryStoredAt,
+				CompletedAt:     &primaryStoredAt,
+			},
+		},
+		"Required locations still apply outside standalone storage": {
+			cfg: pipeline.RecoveryConfig{
+				RequiredLocations:   []string{"replica-loc"},
+				StandaloneLocations: []string{"standalone-loc"},
+			},
+			pkg: &pipeline.StoragePackage{
+				StoredDate: &primaryStoredAt,
+				CurrentLocation: pipeline.StorageLocation{
+					UUID: "cloud-loc",
+				},
+			},
+			want: Result{
+				Classification: ClassificationReplicatedPartial,
+				Status:         StatusPartial,
+				PrimaryExists:  true,
+				AIPStoredAt:    &primaryStoredAt,
+			},
+		},
 		"Replicated storage is partial when a required replica has no stored date": {
 			cfg: pipeline.RecoveryConfig{
 				RequiredLocations: []string{"loc-1"},

--- a/internal/validation/validate_test.go
+++ b/internal/validation/validate_test.go
@@ -50,7 +50,6 @@ func TestChecksumExistsValidator(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			tmpDir := fs.NewDir(t, "transfer", tc.dirOpts...)
 			defer tmpDir.Remove()

--- a/internal/workflow/activities/reconcile_storage_test.go
+++ b/internal/workflow/activities/reconcile_storage_test.go
@@ -92,6 +92,45 @@ func TestReconcileStorageActivityExecute(t *testing.T) {
 		assert.Equal(t, *res.CompletedAt, "2026-03-17T08:00:00Z")
 	})
 
+	t.Run("Classifies standalone completion", func(t *testing.T) {
+		t.Parallel()
+
+		activity := newReconcileStorageActivityForTest(t, pipeline.Config{
+			Name: "am",
+			ID:   "pipeline-1",
+			Recovery: pipeline.RecoveryConfig{
+				ReconcileExistingAIP: true,
+				RequiredLocations:    []string{"loc-1"},
+				StandaloneLocations:  []string{"standalone-loc"},
+			},
+			StorageServiceURL: "http://user:key@example.com",
+		}, func(context.Context, *pipeline.Pipeline, string) (*pipeline.StoragePackage, error) {
+			primaryStoredAt := parseTestTime(t, "2026-03-17T07:00:00Z")
+
+			return &pipeline.StoragePackage{
+				UUID:            "aip-123",
+				Status:          "UPLOADED",
+				StoredDate:      &primaryStoredAt,
+				CurrentFullPath: "/var/aips/aip-123.7z",
+				CurrentLocation: pipeline.StorageLocation{UUID: "standalone-loc"},
+			}, nil
+		})
+
+		res, err := activity.Execute(context.Background(), &ReconcileStorageActivityParams{
+			PipelineName: "am",
+			AIPID:        "aip-123",
+		})
+
+		assert.NilError(t, err)
+		assert.Equal(t, res.Classification, reconciliation.ClassificationLocalComplete)
+		assert.Equal(t, res.Status, reconciliation.StatusComplete)
+		assert.Equal(t, res.PrimaryExists, true)
+		assert.Equal(t, res.StorageComplete, true)
+		assert.Assert(t, res.AIPStoredAt != nil)
+		assert.Assert(t, res.CompletedAt != nil)
+		assert.Equal(t, *res.CompletedAt, "2026-03-17T07:00:00Z")
+	})
+
 	t.Run("Returns transport errors", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
Add standaloneLocations to pipeline recovery configuration so packages stored in
configured final AIP locations can complete from their primary stored date.

Make reconciliation load the primary package before deciding whether replica
hydration is required. This avoids unrelated replica lookup failures for
standalone destinations while preserving required replica checks elsewhere.

Document the setting and cover config decoding, classification, Storage Service
loading, and activity-level reconciliation behavior.