### PR TITLE
Preserve first collection start time

### DIFF
--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -141,6 +141,27 @@ Archivematica transfer ID yet, canceling prevents submission to Archivematica.
 Delete removes the Enduro collection record and does not cancel processing that
 has already been started elsewhere.
 
+## Collection timeline fields
+
+Collection timestamps describe different parts of the Enduro, Archivematica, and
+Storage Service workflow. Some values are recorded by Enduro, while others can
+come from Storage Service when recovery is enabled.
+
+The API returns timestamps as UTC date-time strings. The dashboard displays those
+same instants in the web browser's local time zone.
+
+| Concept | API field | Dashboard location | Meaning |
+| --- | --- | --- | --- |
+| Collection created | `created_at` | Collection detail `Overview` tab, shown as `Created` | When Enduro created the collection record. A collection may remain `queued` after this time while it waits for pipeline capacity. |
+| Processing first started | `started_at` | Collections page, shown as `Started`; collection detail `Overview` tab, shown as `Started` | The first time Enduro acquired pipeline capacity and began processing the collection. Retries do not replace an already recorded value. |
+| Storage complete | `completed_at` | Collections page, shown as `Stored`; collection detail `Overview` tab, shown as `Stored` | The time Enduro treats the collection as stored. For a normal ingest this is the ingest/storage completion time. With storage reconciliation, this can come from Storage Service rather than the local workflow clock. |
+| Primary AIP stored | `aip_stored_at` | Collection detail `Storage` tab, shown as `Primary AIP stored at` | The time Storage Service reports for the primary AIP package. This is available only when Enduro has recorded storage reconciliation data. |
+| Storage last checked | `reconciliation_checked_at` | Collection detail `Storage` tab, shown as `Last checked at` | When Enduro last checked Storage Service for this collection. |
+
+In normal operation, `Started` is recorded once and remains the first processing
+start time for the collection. `Stored` records storage completion, not the time
+of the most recent retry.
+
 ## Pipeline capacity
 
 Pipeline capacity is the main operator-facing control for concurrent ingest

--- a/internal/collection/collection.go
+++ b/internal/collection/collection.go
@@ -186,7 +186,7 @@ func (svc *collectionImpl) SetStatusInProgress(ctx context.Context, ID uint, sta
 	args := []any{StatusInProgress}
 
 	if !startedAt.IsZero() {
-		query = `UPDATE collection SET status = (?), started_at = (?) WHERE id = (?)`
+		query = `UPDATE collection SET status = (?), started_at = COALESCE(started_at, (?)) WHERE id = (?)`
 		args = append(args, startedAt, ID)
 	} else {
 		query = `UPDATE collection SET status = (?) WHERE id = (?)`

--- a/internal/collection/collection_test.go
+++ b/internal/collection/collection_test.go
@@ -59,6 +59,44 @@ func TestUpdateReconciliationState(t *testing.T) {
 	})
 }
 
+func TestSetStatusInProgress(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Preserves an existing started_at value", func(t *testing.T) {
+		t.Parallel()
+
+		recorder := newExecRecorderDB(t)
+		svc := NewService(testLogger(), recorder.db, nil, "", nil)
+		startedAt := time.Date(2026, time.June, 24, 8, 30, 0, 0, time.UTC)
+
+		err := svc.SetStatusInProgress(context.Background(), 42, startedAt)
+
+		assert.NilError(t, err)
+		assert.Equal(t, recorder.query, "UPDATE collection SET status = (?), started_at = COALESCE(started_at, (?)) WHERE id = (?)")
+		assert.DeepEqual(t, recorder.args, []any{
+			int64(StatusInProgress),
+			startedAt,
+			int64(42),
+		})
+	})
+
+	t.Run("Updates only the status without a started_at value", func(t *testing.T) {
+		t.Parallel()
+
+		recorder := newExecRecorderDB(t)
+		svc := NewService(testLogger(), recorder.db, nil, "", nil)
+
+		err := svc.SetStatusInProgress(context.Background(), 42, time.Time{})
+
+		assert.NilError(t, err)
+		assert.Equal(t, recorder.query, "UPDATE collection SET status = (?) WHERE id = (?)")
+		assert.DeepEqual(t, recorder.args, []any{
+			int64(StatusInProgress),
+			int64(42),
+		})
+	})
+}
+
 type execRecorderDB struct {
 	db *sql.DB
 

--- a/ui/src/views/CollectionShow.vue
+++ b/ui/src/views/CollectionShow.vue
@@ -47,7 +47,9 @@
           <dt>Stored</dt>
           <dd>
             {{ collection.completedAt | formatDateTime }}
-            (took {{ collection.startedAt | formatDuration(collection.completedAt) }})
+            <template v-if="showStoredDuration">
+              (took {{ collection.startedAt | formatDuration(collection.completedAt) }})
+            </template>
           </dd>
         </template>
 
@@ -198,6 +200,13 @@ export default class CollectionShow extends Vue {
       return false;
     }
     return this.collection.status == 'in progress' || (this.collection.status == 'queued' && !this.collection.transferId);
+  }
+
+  private get showStoredDuration() {
+    if (!this.collection || !this.collection.startedAt || !this.collection.completedAt) {
+      return false;
+    }
+    return this.collection.completedAt >= this.collection.startedAt;
   }
 
   private onDelete() {


### PR DESCRIPTION
Keep started_at as the first time a collection enters processing instead of replacing it on retry or recovery runs. This restores the expected timeline between the Started and Stored values while leaving existing API fields intact.

Document the collection timeline fields in the user manual and hide the Overview duration when existing data has an inverted timeline.