### PR TITLE
Clarify collection deletion workflow

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -287,9 +287,10 @@ E.g.: `"10m"`
 
 #### `rejectDuplicates` (Boolean)
 
-When enabled, the workflow will execute a check on the internal database for
-successfully completed transfers with the same transfer name as the currently
-processing package. If it finds a duplicate the transfer will fail.
+When enabled, the workflow checks the internal database for another collection
+with the same transfer name as the currently processing package. Existing
+collections in `error` or `abandoned` are ignored. If Enduro finds another
+matching collection, the transfer fails.
 
 E.g.: `false`
 
@@ -441,9 +442,10 @@ E.g.: `"10m"`
 
 #### `rejectDuplicates` (Boolean)
 
-When enabled, the workflow will execute a check on the internal database for
-successfully completed transfers with the same transfer name as the currently
-processing package. If it finds a duplicate the transfer will fail.
+When enabled, the workflow checks the internal database for another collection
+with the same transfer name as the currently processing package. Existing
+collections in `error` or `abandoned` are ignored. If Enduro finds another
+matching collection, the transfer fails.
 
 E.g.: `false`
 

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -142,6 +142,28 @@ Archivematica transfer ID yet, canceling prevents submission to Archivematica.
 Delete removes the Enduro collection record and does not cancel processing that
 has already been started elsewhere.
 
+### Choosing Retry, Abandon, Cancel, or Delete
+
+Use Retry when Enduro should attempt to process the same collection again.
+Retry is available for failed collections and abandoned collections. Bulk Retry
+can target both `error` and `abandoned` collections.
+
+Use Abandon only when a collection is `pending` and Enduro is waiting for an
+operator decision. Abandon records that the pending workflow should stop instead
+of retrying the failed activity. It is not the normal action for a workflow that
+has already ended in `error`.
+
+Use Delete when the Enduro record should no longer be tracked, for example test
+imports, accidental submissions, duplicate entries, or packages that will be
+rebagged and submitted again in a new batch. Delete removes the Enduro
+collection row only. It does not cancel already-started processing, delete AIPs,
+or remove Archivematica transfer or ingest records.
+
+When duplicate rejection is enabled, Enduro ignores existing collections that
+are already in `error` or `abandoned` while checking for duplicate names. If a
+new rebagged package is still rejected as a duplicate, look for another existing
+collection with the same name that is not in `error` or `abandoned`.
+
 ## Collection timeline fields
 
 Collection timestamps describe different parts of the Enduro, Archivematica, and

--- a/frontend/app/pages/collections/[id]/index.vue
+++ b/frontend/app/pages/collections/[id]/index.vue
@@ -23,6 +23,12 @@ const {
 } = useCollectionDetails()
 const backToCollectionsRoute = useCollectionsListLocation()
 const deleteDialogOpen = ref(false)
+const deleteDialogDescription = [
+  'Delete removes the Enduro collection record only.',
+  'It does not cancel already-started processing, delete AIPs, or remove',
+  'Archivematica transfer or ingest records.',
+  'This operation cannot be reversed.'
+].join(' ')
 
 const isBusy = computed(() => isLoading.value || activeAction.value !== null)
 
@@ -383,7 +389,7 @@ async function confirmDelete() {
     <AppConfirmDialog
       v-model:open="deleteDialogOpen"
       title="Delete collection?"
-      description="This operation cannot be reversed."
+      :description="deleteDialogDescription"
       confirm-label="Delete"
       confirm-color="error"
       :pending="activeAction === 'delete'"

--- a/internal/collection/collection.go
+++ b/internal/collection/collection.go
@@ -93,9 +93,9 @@ func (svc *collectionImpl) Create(ctx context.Context, col *Collection) error {
 }
 
 func (svc *collectionImpl) CheckDuplicate(ctx context.Context, id uint) (bool, error) {
-	query := `SELECT EXISTS(SELECT 1 FROM collection c1 WHERE c1.name = (SELECT name FROM collection WHERE id = ?) AND c1.id <> ? AND c1.status NOT IN (3, 6))`
+	query := `SELECT EXISTS(SELECT 1 FROM collection c1 WHERE c1.name = (SELECT name FROM collection WHERE id = ?) AND c1.id <> ? AND c1.status NOT IN (?, ?))`
 	var exists bool
-	err := svc.db.GetContext(ctx, &exists, query, id, id)
+	err := svc.db.GetContext(ctx, &exists, query, id, id, StatusError, StatusAbandoned)
 	if err != nil {
 		return false, fmt.Errorf("sql error: %w", err)
 	}

--- a/internal/collection/collection_test.go
+++ b/internal/collection/collection_test.go
@@ -97,6 +97,27 @@ func TestSetStatusInProgress(t *testing.T) {
 	})
 }
 
+func TestCheckDuplicateIgnoresFailedAndAbandonedCollections(t *testing.T) {
+	t.Parallel()
+
+	duplicateExists := false
+	recorder := newExecRecorderDB(t)
+	recorder.queryBool = &duplicateExists
+	svc := NewService(testLogger(), recorder.db, nil, "", nil)
+
+	got, err := svc.CheckDuplicate(context.Background(), 42)
+
+	assert.NilError(t, err)
+	assert.Equal(t, got, false)
+	assert.Equal(t, recorder.querySQL, "SELECT EXISTS(SELECT 1 FROM collection c1 WHERE c1.name = (SELECT name FROM collection WHERE id = ?) AND c1.id <> ? AND c1.status NOT IN (?, ?))")
+	assert.DeepEqual(t, recorder.queryArgs, []any{
+		int64(42),
+		int64(42),
+		int64(StatusError),
+		int64(StatusAbandoned),
+	})
+}
+
 type execRecorderDB struct {
 	db *sql.DB
 
@@ -112,6 +133,7 @@ type execRecorderDB struct {
 	execErr      error
 	queryErr     error
 	row          *Collection
+	queryBool    *bool
 }
 
 var execRecorderDriverID atomic.Uint64
@@ -181,8 +203,34 @@ func (c execRecorderConn) QueryContext(_ context.Context, query string, args []d
 	if c.recorder.queryErr != nil {
 		return nil, c.recorder.queryErr
 	}
+	if c.recorder.queryBool != nil {
+		return &boolRows{value: *c.recorder.queryBool}, nil
+	}
 
 	return &collectionRows{row: c.recorder.row}, nil
+}
+
+type boolRows struct {
+	value bool
+	done  bool
+}
+
+func (r *boolRows) Columns() []string {
+	return []string{"exists"}
+}
+
+func (r *boolRows) Close() error {
+	return nil
+}
+
+func (r *boolRows) Next(dest []driver.Value) error {
+	if r.done {
+		return io.EOF
+	}
+	r.done = true
+	dest[0] = r.value
+
+	return nil
 }
 
 type collectionRows struct {

--- a/ui/src/views/CollectionShow.vue
+++ b/ui/src/views/CollectionShow.vue
@@ -69,7 +69,9 @@
 
         <b-link class="small" v-if="!isRunning" v-b-modal="'delete-modal'">Delete</b-link>
         <b-modal id="delete-modal" @ok="onDeleteConfirmed()" title="Are you sure?">
-          Once completed, this operation cannot be reversed.
+          Delete removes the Enduro collection record only. It does not cancel
+          already-started processing, delete AIPs, or remove Archivematica
+          transfer or ingest records. This operation cannot be reversed.
           <template v-slot:modal-footer="{ ok, cancel, hide }">
             <b-button size="sm" variant="danger" @click="ok()">Delete</b-button>
             <b-button size="sm" variant="light" @click="cancel()">Cancel</b-button>


### PR DESCRIPTION
Document when operators should retry, abandon, cancel, or delete collections. Make the dashboard delete confirmation explicit that Delete only removes the Enduro collection record and does not cancel processing or remove Archivematica records.

Use named status constants in duplicate checking and add coverage showing that failed and abandoned collections are ignored by duplicate rejection.

Fixes #182.