### PR TITLE
Clarify collection start date labels

### DIFF
--- a/frontend/app/pages/collections/[id]/index.nuxt.spec.ts
+++ b/frontend/app/pages/collections/[id]/index.nuxt.spec.ts
@@ -1,0 +1,92 @@
+import { ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mountSuspended, mockComponent, mockNuxtImport } from '@nuxt/test-utils/runtime'
+
+import CollectionOverviewPage from './index.vue'
+
+const { useCollectionDetailsMock, useCollectionsListLocationMock } = vi.hoisted(() => ({
+  useCollectionDetailsMock: vi.fn(),
+  useCollectionsListLocationMock: vi.fn()
+}))
+
+mockNuxtImport('useCollectionDetails', () => useCollectionDetailsMock)
+mockNuxtImport('useCollectionsListLocation', () => useCollectionsListLocationMock)
+
+mockComponent('AppUuid', async () => {
+  const { defineComponent, h } = await import('vue')
+
+  return defineComponent({
+    props: {
+      value: {
+        type: String,
+        default: ''
+      }
+    },
+    setup(props) {
+      return () => h('span', props.value)
+    }
+  })
+})
+
+function createCollectionDetailsState(collectionOverrides: { startedAt?: Date } = {}) {
+  return {
+    activeAction: ref(null),
+    actionErrorMessage: ref(''),
+    canCancel: ref(false),
+    canDelete: ref(false),
+    canRetry: ref(false),
+    collection: ref({
+      id: 77,
+      createdAt: new Date('2026-04-22T18:45:00.000Z'),
+      startedAt: new Date('2026-04-22T18:47:00.000Z'),
+      status: 'in progress',
+      workflowId: 'workflow-77',
+      runId: 'run-77',
+      ...collectionOverrides
+    }),
+    errorMessage: ref(''),
+    hasLoaded: ref(true),
+    isLoading: ref(false),
+    isPending: ref(false),
+    pipeline: ref(null),
+    retryModeMessage: ref(''),
+    cancel: vi.fn(),
+    decide: vi.fn(),
+    dismissRetryModeMessage: vi.fn(),
+    reload: vi.fn(),
+    remove: vi.fn(),
+    retry: vi.fn()
+  }
+}
+
+describe('collection overview page', () => {
+  beforeEach(() => {
+    useCollectionDetailsMock.mockReset()
+    useCollectionDetailsMock.mockReturnValue(createCollectionDetailsState())
+    useCollectionsListLocationMock.mockReset()
+    useCollectionsListLocationMock.mockReturnValue(ref({ path: '/collections', query: {} }))
+  })
+
+  it('identifies the processing start time explicitly', async () => {
+    const wrapper = await mountSuspended(CollectionOverviewPage, {
+      route: '/collections/77'
+    })
+
+    const labels = wrapper.findAll('dt').map(label => label.text())
+    expect(labels).toContain('Created')
+    expect(labels).toContain('Processing started')
+    expect(labels).not.toContain('Workflow started')
+  })
+
+  it('explains when collection processing has not started', async () => {
+    useCollectionDetailsMock.mockReturnValue(createCollectionDetailsState({ startedAt: undefined }))
+
+    const wrapper = await mountSuspended(CollectionOverviewPage, {
+      route: '/collections/77'
+    })
+
+    const labels = wrapper.findAll('dt').map(label => label.text())
+    expect(labels).toContain('Processing started')
+    expect(wrapper.text()).toContain('Processing has not started yet.')
+  })
+})

--- a/frontend/app/pages/collections/[id]/index.vue
+++ b/frontend/app/pages/collections/[id]/index.vue
@@ -42,7 +42,7 @@ const overviewItems = computed(() => {
   const items: Array<{ key: string, label: string, slot?: string, value?: string, valueClass?: string }> = [
     { key: 'status', label: 'Status', slot: 'status' },
     { key: 'created', label: 'Created', value: formatDateTime(collection.value.createdAt) },
-    { key: 'started', label: 'Started', value: collection.value.startedAt ? formatDateTime(collection.value.startedAt) : 'Not started yet.' }
+    { key: 'started', label: 'Processing started', value: collection.value.startedAt ? formatDateTime(collection.value.startedAt) : 'Processing has not started yet.' }
   ]
 
   if (collection.value.originalId) {

--- a/frontend/app/pages/collections/[id]/workflow.nuxt.spec.ts
+++ b/frontend/app/pages/collections/[id]/workflow.nuxt.spec.ts
@@ -86,15 +86,27 @@ describe('workflow page', () => {
     useCollectionWorkflowMock.mockReset()
   })
 
-  it('renders started and completed metadata when timestamps are present', async () => {
+  it('labels the workflow start time explicitly', async () => {
     useCollectionWorkflowMock.mockReturnValue(createWorkflowState())
 
     const wrapper = await mountSuspended(WorkflowPage, {
       route: '/collections/77/workflow'
     })
 
-    expect(wrapper.text()).toContain('Started')
-    expect(wrapper.text()).toContain('Completed')
+    const labels = wrapper.findAll('dt').map(label => label.text())
+    expect(labels).toContain('Workflow started')
+    expect(labels).not.toContain('Processing started')
+  })
+
+  it('renders workflow completion metadata and duration', async () => {
+    useCollectionWorkflowMock.mockReturnValue(createWorkflowState())
+
+    const wrapper = await mountSuspended(WorkflowPage, {
+      route: '/collections/77/workflow'
+    })
+
+    const labels = wrapper.findAll('dt').map(label => label.text())
+    expect(labels).toContain('Completed')
     expect(wrapper.text()).toContain('COMPLETED')
     expect(wrapper.text()).toContain('took 5m')
   })

--- a/frontend/app/pages/collections/[id]/workflow.vue
+++ b/frontend/app/pages/collections/[id]/workflow.vue
@@ -34,7 +34,7 @@ const metadataItems = computed(() => {
   ]
 
   if (workflow.startedAt) {
-    items.push({ key: 'startedAt', label: 'Started', value: formatDateTime(workflow.startedAt) })
+    items.push({ key: 'startedAt', label: 'Workflow started', value: formatDateTime(workflow.startedAt) })
   }
 
   if (workflow.completedAt) {

--- a/frontend/app/pages/collections/index.nuxt.spec.ts
+++ b/frontend/app/pages/collections/index.nuxt.spec.ts
@@ -93,6 +93,18 @@ describe('collections index page', () => {
     expect(wrapper.text()).toContain('transfer2.zip')
   })
 
+  it('labels the collection processing start explicitly', async () => {
+    useCollectionsBrowserMock.mockReturnValue(createCollectionsBrowserState())
+    useDashboardUiOptionsMock.mockReturnValue(createDashboardUiOptionsState())
+
+    const wrapper = await mountSuspended(CollectionsPage, {
+      route: '/collections'
+    })
+
+    const headers = wrapper.findAll('th').map(header => header.text())
+    expect(headers).toContain('Processing started')
+  })
+
   it('opens the search panel from the toolbar toggle', async () => {
     useCollectionsBrowserMock.mockReturnValue(createCollectionsBrowserState())
     const uiOptions = createDashboardUiOptionsState()

--- a/frontend/app/pages/collections/index.vue
+++ b/frontend/app/pages/collections/index.vue
@@ -13,7 +13,7 @@ const columns: TableColumn<EnduroStoredCollection>[] = [
   },
   {
     accessorKey: 'startedAt',
-    header: 'Started'
+    header: 'Processing started'
   },
   {
     accessorKey: 'completedAt',


### PR DESCRIPTION
Label collection started_at values as "Processing started" in the list and overview, including the not-started placeholder. Label the Temporal WorkflowExecutionStarted timestamp as "Workflow started" so the two events are not presented as equivalent.

Add page-level tests for the collection-list header, overview label and empty state, and workflow timing metadata.

Fixes #138.