### PR TITLE
Prevent duplicate AIPs on transfer retries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
-	go.artefactual.dev/amclient v0.4.0
+	go.artefactual.dev/amclient v0.5.0
 	go.artefactual.dev/ssclient v0.11.0
 	go.artefactual.dev/tools v0.25.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.69.0

--- a/go.sum
+++ b/go.sum
@@ -447,8 +447,8 @@ github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=
 github.com/zeebo/xxh3 v1.1.0/go.mod h1:IisAie1LELR4xhVinxWS5+zf1lA4p0MW4T+w+W07F5s=
-go.artefactual.dev/amclient v0.4.0 h1:B/VeBJ72R5zTzcSk5ErrQnrcUYkUd+M30I5ga+YZkjI=
-go.artefactual.dev/amclient v0.4.0/go.mod h1:oAOlZHC78IWjWDCqRM1/8K1x/WYmRUL3peujKCdoXaA=
+go.artefactual.dev/amclient v0.5.0 h1:qMxc/9VRRONtRIAXs+qHs3PCDhClGZjQHqjBwjsv/w8=
+go.artefactual.dev/amclient v0.5.0/go.mod h1:v2rDC3LY33Yaf8CYB+dP7Q0Rkwco6orEpvbnFMtiuL4=
 go.artefactual.dev/ssclient v0.11.0 h1:mRjB8J0IQ+gjg6ICtZxJm+whG56tvIyxT+x4bO6CQGc=
 go.artefactual.dev/ssclient v0.11.0/go.mod h1:0tO5nOwQ8naw+GcPBi2A7lXzPt4HUn7MPXqQwi7H3jY=
 go.artefactual.dev/tools v0.25.1 h1:kpnaIyv+60ip0IdaY4V1S6B6A+NQzVOHS+CGubp/kWw=

--- a/internal/workflow/activities/transfer.go
+++ b/internal/workflow/activities/transfer.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"go.artefactual.dev/amclient"
+	temporalsdk_activity "go.temporal.io/sdk/activity"
 
 	"github.com/artefactual-labs/enduro/internal/pipeline"
 	"github.com/artefactual-labs/enduro/internal/temporal"
@@ -45,6 +46,20 @@ func (a *TransferActivity) Execute(ctx context.Context, params *TransferActivity
 		return nil, temporal.NewNonRetryableError(err)
 	}
 	amc := p.Client()
+	logger := temporalsdk_activity.GetLogger(ctx)
+
+	idempotencyKey := ""
+	serverInfo, _, err := amc.ServerInfo(ctx)
+	if err != nil {
+		logger.Warn(
+			"Unable to determine Archivematica version; submitting transfer without an idempotency key.",
+			"error", err,
+		)
+	} else if serverInfo.Version.AtLeast(1, 19, 0) {
+		idempotencyKey = transferIdempotencyKey(
+			temporalsdk_activity.GetInfo(ctx),
+		)
+	}
 
 	// Transfer path should include the location UUID if defined.
 	path := params.RelPath
@@ -52,19 +67,23 @@ func (a *TransferActivity) Execute(ctx context.Context, params *TransferActivity
 		path = fmt.Sprintf("%s:%s", params.TransferLocationID, path)
 	}
 
+	autoApprove := true
 	resp, httpResp, err := amc.Package.Create(ctx, &amclient.PackageCreateRequest{
 		Name:             params.Name,
 		Type:             params.TransferType,
 		Path:             path,
 		ProcessingConfig: params.ProcessingConfig,
-		AutoApprove:      true,
+		AutoApprove:      &autoApprove,
 		Accession:        params.Accession,
+		IdempotencyKey:   idempotencyKey,
 	})
 	if err != nil {
 		if httpResp != nil {
 			switch httpResp.StatusCode {
 			case http.StatusForbidden:
 				return nil, temporal.NewNonRetryableError(fmt.Errorf("authentication error: %v", err))
+			case http.StatusUnprocessableEntity:
+				return nil, temporal.NewNonRetryableError(fmt.Errorf("invalid transfer request: %v", err))
 			}
 		}
 		return nil, err
@@ -75,4 +94,32 @@ func (a *TransferActivity) Execute(ctx context.Context, params *TransferActivity
 		PipelineVersion: httpResp.Header.Get("X-Archivematica-Version"),
 		PipelineID:      httpResp.Header.Get("X-Archivematica-ID"),
 	}, nil
+}
+
+// transferIdempotencyKey returns the identity of the single logical transfer
+// submission made by a Temporal workflow run.
+//
+// Temporal may execute TransferActivity more than once because of its activity
+// retry policy or because Enduro recreates a failed worker session. Those
+// attempts retain the workflow run ID and must reuse the same key so
+// Archivematica can replay the original transfer UUID instead of creating a
+// duplicate transfer.
+//
+// Enduro's operator-triggered Retry behaves differently: it keeps the workflow
+// ID but starts a new workflow run, and full reprocessing intentionally submits
+// a new Archivematica transfer. A collection ID or workflow ID would therefore
+// remain stable for too long, while the run ID matches the intended submission
+// boundary.
+//
+// This assumes that a workflow run submits at most one transfer. If Enduro adds
+// multiple submissions per run, workflow-level retries, Continue-As-New, or a
+// way to recover an ambiguous submission across operator retries, this key must
+// be replaced by a persisted logical submission ID.
+func transferIdempotencyKey(info temporalsdk_activity.Info) string {
+	runID := info.WorkflowExecution.RunID
+	if runID == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("enduro-transfer-%s", runID)
 }

--- a/internal/workflow/activities/transfer_test.go
+++ b/internal/workflow/activities/transfer_test.go
@@ -1,0 +1,201 @@
+package activities
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	temporalsdk_activity "go.temporal.io/sdk/activity"
+	temporalsdk_testsuite "go.temporal.io/sdk/testsuite"
+	"gotest.tools/v3/assert"
+
+	"github.com/artefactual-labs/enduro/internal/temporal"
+)
+
+func TestTransferActivityIdempotencyVersionGate(t *testing.T) {
+	tests := map[string]struct {
+		version        string
+		serverInfoCode int
+		wantKey        bool
+	}{
+		"Older server": {
+			version:        "1.18.9",
+			serverInfoCode: http.StatusNotImplemented,
+		},
+		"Minimum supported server": {
+			version:        "1.19.0",
+			serverInfoCode: http.StatusNotImplemented,
+			wantKey:        true,
+		},
+		"Newer server": {
+			version:        "2.0.0",
+			serverInfoCode: http.StatusNotImplemented,
+			wantKey:        true,
+		},
+		"Missing version": {
+			serverInfoCode: http.StatusNotImplemented,
+		},
+		"Malformed version": {
+			version:        "development",
+			serverInfoCode: http.StatusNotImplemented,
+		},
+		"Failed discovery": {
+			serverInfoCode: http.StatusInternalServerError,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var (
+				getRequests  int
+				postRequests int
+				gotKey       string
+			)
+			pipelineRegistry := newPipelineRegistry(t, func(w http.ResponseWriter, r *http.Request) {
+				switch r.Method {
+				case http.MethodGet:
+					getRequests++
+					if tc.version != "" {
+						w.Header().Set("X-Archivematica-Version", tc.version)
+					}
+					w.WriteHeader(tc.serverInfoCode)
+				case http.MethodPost:
+					postRequests++
+					gotKey = r.Header.Get("Idempotency-Key")
+					w.Header().Set("X-Archivematica-Version", "1.19.0")
+					w.Header().Set("X-Archivematica-ID", "pipeline-id")
+					w.WriteHeader(http.StatusAccepted)
+					fmt.Fprint(w, `{"id":"transfer-id"}`)
+				default:
+					t.Fatalf("unexpected request method: %s", r.Method)
+				}
+			})
+
+			result, err := executeTransferActivity(t, NewTransferActivity(pipelineRegistry))
+
+			assert.NilError(t, err)
+			assert.Equal(t, result.TransferID, "transfer-id")
+			assert.Equal(t, result.PipelineID, "pipeline-id")
+			assert.Equal(t, getRequests, 1)
+			assert.Equal(t, postRequests, 1)
+			if tc.wantKey {
+				assert.Assert(t, strings.HasPrefix(gotKey, "enduro-transfer-"))
+				return
+			}
+			assert.Equal(t, gotKey, "")
+		})
+	}
+}
+
+func TestTransferActivityChecksVersionEveryAttempt(t *testing.T) {
+	var (
+		serverInfoRequests int
+		gotKeys            []string
+	)
+	pipelineRegistry := newPipelineRegistry(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			serverInfoRequests++
+			version := "1.18.9"
+			if serverInfoRequests > 1 {
+				version = "1.19.0"
+			}
+			w.Header().Set("X-Archivematica-Version", version)
+			w.WriteHeader(http.StatusNotImplemented)
+		case http.MethodPost:
+			gotKeys = append(gotKeys, r.Header.Get("Idempotency-Key"))
+			w.WriteHeader(http.StatusAccepted)
+			fmt.Fprint(w, `{"id":"transfer-id"}`)
+		default:
+			t.Fatalf("unexpected request method: %s", r.Method)
+		}
+	})
+	activity := NewTransferActivity(pipelineRegistry)
+
+	for range 2 {
+		_, err := executeTransferActivity(t, activity)
+		assert.NilError(t, err)
+	}
+
+	assert.Equal(t, serverInfoRequests, 2)
+	assert.Equal(t, len(gotKeys), 2)
+	assert.Equal(t, gotKeys[0], "")
+	assert.Assert(t, strings.HasPrefix(gotKeys[1], "enduro-transfer-"))
+}
+
+func TestTransferActivityIdempotencyErrors(t *testing.T) {
+	tests := map[string]struct {
+		statusCode   int
+		nonRetryable bool
+	}{
+		"Request in progress remains retryable": {
+			statusCode: http.StatusConflict,
+		},
+		"Changed request is not retryable": {
+			statusCode:   http.StatusUnprocessableEntity,
+			nonRetryable: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			pipelineRegistry := newPipelineRegistry(t, func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodGet {
+					w.Header().Set("X-Archivematica-Version", "1.19.0")
+					w.WriteHeader(http.StatusNotImplemented)
+					return
+				}
+				w.WriteHeader(tc.statusCode)
+			})
+
+			result, err := executeTransferActivity(t, NewTransferActivity(pipelineRegistry))
+
+			assert.Assert(t, result == nil)
+			assert.Assert(t, err != nil)
+			assert.Equal(t, temporal.NonRetryableError(err), tc.nonRetryable)
+			assert.ErrorContains(t, err, fmt.Sprintf("%d", tc.statusCode))
+		})
+	}
+}
+
+func TestTransferIdempotencyKey(t *testing.T) {
+	info := temporalsdk_activity.Info{}
+	assert.Equal(t, transferIdempotencyKey(info), "")
+
+	info.WorkflowExecution.RunID = "run-id"
+	assert.Equal(t, transferIdempotencyKey(info), "enduro-transfer-run-id")
+	assert.Equal(t, transferIdempotencyKey(info), transferIdempotencyKey(info))
+
+	otherInfo := info
+	otherInfo.WorkflowExecution.RunID = "other-run-id"
+	assert.Assert(t, transferIdempotencyKey(info) != transferIdempotencyKey(otherInfo))
+}
+
+func executeTransferActivity(t *testing.T, activity *TransferActivity) (*TransferActivityResponse, error) {
+	t.Helper()
+
+	s := temporalsdk_testsuite.WorkflowTestSuite{}
+	env := s.NewTestActivityEnvironment()
+	env.RegisterActivity(activity.Execute)
+
+	future, err := env.ExecuteActivity(activity.Execute, &TransferActivityParams{
+		PipelineName:       "am",
+		TransferLocationID: "location-id",
+		RelPath:            "transfer/path",
+		Name:               "transfer",
+		ProcessingConfig:   "automated",
+		TransferType:       "standard",
+		Accession:          "accession",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	result := &TransferActivityResponse{}
+	if err := future.Get(result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}


### PR DESCRIPTION
Consider a transfer that Archivematica accepts just as the connection to Enduro drops. Enduro never receives the success response, so Temporal retries the activity and submits the transfer again. Without an idempotency key, Archivematica cannot recognize both requests as the same operation. The retry can therefore create a second transfer and eventually a duplicate AIP. This change gives retries a stable identity, protecting operators when the outcome of the first request is uncertain.

Upgrade amclient and send a workflow-run-scoped idempotency key to Archivematica 1.19.0 and newer. Probe the server before each attempt. Preserve unkeyed behavior for older or undiscoverable versions, retry in-progress requests, and stop retrying key conflicts.